### PR TITLE
Feather/fault tolerance

### DIFF
--- a/Agent/causal_agent/fault_tolerance.py
+++ b/Agent/causal_agent/fault_tolerance.py
@@ -1,0 +1,150 @@
+"""
+LangGraph 节点级容错策略。
+
+本模块只定义图运行时策略和错误恢复状态，不直接写数据库、不直接操作 SSE。
+worker 仍负责把 graph 产出的终态或异常转换为 analysis_job_events。
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from langchain_core.messages import AIMessage
+from langgraph.errors import NodeError
+from langgraph.types import Command, RetryPolicy, TimeoutPolicy, default_retry_on
+
+from .state import CausalChatState
+
+
+def retry_transient_errors(exc: BaseException) -> bool:
+    """
+    判断异常是否适合交给 LangGraph 进行节点级重试。
+
+    默认策略已排除常见编程错误，并会重试 NodeTimeoutError 以及常见 5xx/网络类异常；
+    这里单独排除 LangGraph interrupt 相关异常，避免“需要用户输入”的业务中断被当作故障重试。
+    """
+    exc_name = exc.__class__.__name__.lower()
+    if "interrupt" in exc_name:
+        return False
+    return default_retry_on(exc)
+
+
+def short_retry(max_attempts: int = 2) -> RetryPolicy:
+    """生成短重试策略，适用于 LLM 路由、总结和普通回答节点。"""
+    return RetryPolicy(
+        max_attempts=max_attempts,
+        initial_interval=0.5,
+        backoff_factor=2.0,
+        max_interval=4.0,
+        retry_on=retry_transient_errors,
+    )
+
+
+def tool_retry(max_attempts: int = 3) -> RetryPolicy:
+    """生成工具调用重试策略，适用于 MCP/RAG 等外部依赖节点。"""
+    return RetryPolicy(
+        max_attempts=max_attempts,
+        initial_interval=1.0,
+        backoff_factor=2.0,
+        max_interval=8.0,
+        retry_on=retry_transient_errors,
+    )
+
+
+def timeout(run_timeout: float, idle_timeout: float | None = None) -> TimeoutPolicy:
+    """生成节点 timeout 策略，run_timeout 是单次 attempt 的硬上限。"""
+    return TimeoutPolicy(run_timeout=run_timeout, idle_timeout=idle_timeout)
+
+
+def _error_message(error: NodeError) -> str:
+    return f"{error.node} 节点执行失败: {error.error}"
+
+
+def route_to_normal_chat(state: CausalChatState, error: NodeError) -> Command:
+    """Agent 路由失败后的保守恢复：进入普通问答兜底分支。"""
+    return Command(
+        update={
+            "messages": [
+                AIMessage(
+                    content=f"决策：普通问答。路由节点降级原因：{_error_message(error)}",
+                    name=error.node,
+                )
+            ]
+        },
+        goto="normal_chat",
+    )
+
+
+def recover_to_agent(state: CausalChatState, error: NodeError) -> Command:
+    """中间节点失败后的恢复：记录失败消息并回到 agent 重新决策。"""
+    return Command(
+        update={
+            "messages": [
+                AIMessage(
+                    content=f"决策：节点失败，返回 agent 重新判断。{_error_message(error)}",
+                    name=error.node,
+                )
+            ],
+            "tool_call_request": False,
+        },
+        goto="agent",
+    )
+
+
+def recover_tools_to_agent(state: CausalChatState, error: NodeError) -> Command:
+    """工具节点失败后的恢复：保留结构化失败结果并回到 agent。"""
+    message = _error_message(error)
+    return Command(
+        update={
+            "messages": [
+                AIMessage(content=f"决策：工具执行失败：{message}", name=error.node)
+            ],
+            "causal_analysis_result": {"success": False, "message": message},
+            "knowledge_base_result": {
+                "success": False,
+                "summary": message,
+                "questions": [],
+                "evidence_count": 0,
+                "error": message,
+            },
+            "tool_call_request": False,
+        },
+        goto="agent",
+    )
+
+
+def recover_postprocess_to_report(state: CausalChatState, error: NodeError) -> Command:
+    """后处理失败后的恢复：使用原始分析结果继续报告生成。"""
+    message = f"{_error_message(error)}；将使用原始分析结果继续生成报告。"
+    return Command(
+        update={
+            "messages": [AIMessage(content=message, name=error.node)],
+            "postprocess_result": {"error": message},
+        },
+        goto="report",
+    )
+
+
+def recover_terminal_message(state: CausalChatState, error: NodeError) -> dict:
+    """终态回答节点失败后的恢复：返回可展示的失败消息，让 graph 正常结束。"""
+    return {
+        "messages": [
+            AIMessage(
+                content=f"抱歉，本次生成回答时发生错误：{_error_message(error)}",
+                name=error.node,
+            )
+        ]
+    }
+
+
+def recover_report(state: CausalChatState, error: NodeError) -> dict:
+    """报告节点失败后的恢复：生成简短兜底报告，让 worker 能走 final_result。"""
+    message = f"报告生成失败：{_error_message(error)}"
+    return {
+        "messages": [AIMessage(content="决策：因果分析报告生成失败。", name=error.node)],
+        "final_report": message,
+        "visualization_mapping": {},
+    }
+
+
+NodeErrorHandler = Callable[[CausalChatState, NodeError], Command | dict]

--- a/Agent/causal_agent/graph.py
+++ b/Agent/causal_agent/graph.py
@@ -1,12 +1,36 @@
-from functools import partial
 from langgraph.graph import StateGraph, END
 from .state import CausalChatState
 from . import nodes, edges
+from .fault_tolerance import (
+    recover_postprocess_to_report,
+    recover_report,
+    recover_terminal_message,
+    recover_tools_to_agent,
+    recover_to_agent,
+    route_to_normal_chat,
+    short_retry,
+    timeout,
+    tool_retry,
+)
 import logging
 
 # === 导入 Checkpoint 相关 ===
 from Database.mysql_checkpointer import MySQLSaver
 from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+
+
+def _bind_node(func, **bound_kwargs):
+    """
+    将共享资源绑定到 async LangGraph 节点。
+
+    使用显式 async wrapper，避免 functools.partial 包装 async function 后被运行时误判为同步节点。
+    """
+    async def _node(state: CausalChatState):
+        return await func(state, **bound_kwargs)
+
+    _node.__name__ = getattr(func, "__name__", "bound_node")
+    return _node
+
 
 def create_graph(llm: "ChatOpenAI", mcp_session: "ClientSession"):
     """
@@ -16,24 +40,71 @@ def create_graph(llm: "ChatOpenAI", mcp_session: "ClientSession"):
 
     # 使用 functools.partial 将 llm 实例绑定到节点函数上
     # 这使得节点在被 LangGraph 调用时，除了 state 之外，还能接收到 llm 对象
-    agent_node_with_llm = partial(nodes.agent_node, llm=llm)
-    fold_node_with_llm = partial(nodes.fold_node, llm=llm)
-    preprocess_node_with_llm = partial(nodes.preprocess_node, llm=llm)
-    execute_tools_node_with_session = partial(nodes.execute_tools_node, mcp_session=mcp_session, llm=llm)
-    postprocess_node_with_llm = partial(nodes.postprocess_node, llm=llm)
-    inquiry_answer_node_with_llm = partial(nodes.inquiry_answer_node, llm=llm)
-    report_node_with_llm = partial(nodes.report_node, llm=llm)
-    normal_chat_node_with_llm = partial(nodes.normal_chat_node, llm=llm)
+    agent_node_with_llm = _bind_node(nodes.agent_node, llm=llm)
+    fold_node_with_llm = _bind_node(nodes.fold_node, llm=llm)
+    preprocess_node_with_llm = _bind_node(nodes.preprocess_node, llm=llm)
+    execute_tools_node_with_session = _bind_node(nodes.execute_tools_node, mcp_session=mcp_session, llm=llm)
+    postprocess_node_with_llm = _bind_node(nodes.postprocess_node, llm=llm)
+    inquiry_answer_node_with_llm = _bind_node(nodes.inquiry_answer_node, llm=llm)
+    report_node_with_llm = _bind_node(nodes.report_node, llm=llm)
+    normal_chat_node_with_llm = _bind_node(nodes.normal_chat_node, llm=llm)
 
     # Add all the nodes to the graph
-    workflow.add_node("agent", agent_node_with_llm)
-    workflow.add_node("fold", fold_node_with_llm)
-    workflow.add_node("preprocess", preprocess_node_with_llm)
-    workflow.add_node("execute_tools", execute_tools_node_with_session)
-    workflow.add_node("postprocess", postprocess_node_with_llm)
-    workflow.add_node("report", report_node_with_llm)
-    workflow.add_node("normal_chat", normal_chat_node_with_llm)
-    workflow.add_node("inquiry_answer", inquiry_answer_node_with_llm)
+    workflow.add_node(
+        "agent",
+        agent_node_with_llm,
+        retry_policy=short_retry(),
+        timeout=timeout(run_timeout=45, idle_timeout=20),
+        error_handler=route_to_normal_chat,
+    )
+    workflow.add_node(
+        "fold",
+        fold_node_with_llm,
+        retry_policy=short_retry(),
+        timeout=timeout(run_timeout=120, idle_timeout=45),
+        error_handler=recover_to_agent,
+    )
+    workflow.add_node(
+        "preprocess",
+        preprocess_node_with_llm,
+        retry_policy=short_retry(),
+        timeout=timeout(run_timeout=180, idle_timeout=60),
+        error_handler=recover_to_agent,
+    )
+    workflow.add_node(
+        "execute_tools",
+        execute_tools_node_with_session,
+        retry_policy=tool_retry(),
+        timeout=timeout(run_timeout=360, idle_timeout=120),
+        error_handler=recover_tools_to_agent,
+    )
+    workflow.add_node(
+        "postprocess",
+        postprocess_node_with_llm,
+        timeout=timeout(run_timeout=240, idle_timeout=90),
+        error_handler=recover_postprocess_to_report,
+    )
+    workflow.add_node(
+        "report",
+        report_node_with_llm,
+        retry_policy=short_retry(),
+        timeout=timeout(run_timeout=180, idle_timeout=60),
+        error_handler=recover_report,
+    )
+    workflow.add_node(
+        "normal_chat",
+        normal_chat_node_with_llm,
+        retry_policy=short_retry(),
+        timeout=timeout(run_timeout=60, idle_timeout=30),
+        error_handler=recover_terminal_message,
+    )
+    workflow.add_node(
+        "inquiry_answer",
+        inquiry_answer_node_with_llm,
+        retry_policy=short_retry(),
+        timeout=timeout(run_timeout=90, idle_timeout=30),
+        error_handler=recover_terminal_message,
+    )
 
     
     # Set the entry point of the graph
@@ -86,6 +157,7 @@ def create_graph(llm: "ChatOpenAI", mcp_session: "ClientSession"):
     # Define the end points of the graph. A graph can have multiple finishing points.
     workflow.add_edge("report", END)
     workflow.add_edge("normal_chat", END)
+    workflow.add_edge("inquiry_answer", END)
     
 
     checkpointer = None

--- a/Agent/causal_agent/nodes.py
+++ b/Agent/causal_agent/nodes.py
@@ -1,4 +1,5 @@
 from .state import CausalChatState
+import asyncio
 from langchain_core.output_parsers import StrOutputParser, JsonOutputParser
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
@@ -41,7 +42,7 @@ class RouteQuery(BaseModel):
     )
 
 # agentnode节点用于做初步的decision
-def agent_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
+async def agent_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
 
     """
     Agent节点，是图的起点，用于判断是否需要进入causal循环，
@@ -92,7 +93,7 @@ def agent_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
     
     logging.info("正在调用LLM进行路由决策...")
     try:
-        decision_dict = runnable.invoke(
+        decision_dict = await runnable.ainvoke(
             {
                 "messages": state["messages"][-1],
                 "has_tool_results": has_tool_results,
@@ -144,7 +145,7 @@ from Agent.Processing.fold_verify import validate_analysis
 from Agent.Processing.data_visualize import generate_visualizations
 
 
-def fold_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
+async def fold_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
     """
     文件加载、解析与验证节点。
     1.  使用LLM从对话中一次性提取文件名、目标和处理变量。
@@ -199,7 +200,7 @@ def fold_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
         ])
     try:
         runnable = prompt | llm | JsonOutputParser()
-        response = runnable.invoke({"messages": state["messages"]})
+        response = await runnable.ainvoke({"messages": state["messages"]})
 
         structured_response = foldQuery.model_validate(response)
 
@@ -226,25 +227,25 @@ def fold_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
     logging.info(f"filename: {filename}, state.get('fold_name'): {state.get('fold_name')}")
     try:
         if filename :
-            file_content_bytes = get_file_content(user_id, filename)
+            file_content_bytes = await asyncio.to_thread(get_file_content, user_id, filename)
             state['fold_name'] = filename
             
             # 注意这里的文件名后续并没有用到
             loaded_filename = filename
         elif state.get('fold_name'):
             loaded_filename = state.get('fold_name')
-            file_content_bytes = get_file_content(user_id, loaded_filename)
+            file_content_bytes = await asyncio.to_thread(get_file_content, user_id, loaded_filename)
 
         else:
-            file_content_bytes , loaded_filename = get_recent_file(user_id)
+            file_content_bytes , loaded_filename = await asyncio.to_thread(get_recent_file, user_id)
 
         if not file_content_bytes or not loaded_filename:
             raise FileNotFoundError("找不到任何可供分析的文件。请先上传一个CSV文件。")
         
         state['fold_name'] = loaded_filename
         file_content_str = file_content_bytes.decode('utf-8')
-        df = pd.read_csv(io.StringIO(file_content_str))
-        data_summary = get_data_summary(df)
+        df = await asyncio.to_thread(pd.read_csv, io.StringIO(file_content_str))
+        data_summary = await asyncio.to_thread(get_data_summary, df)
     
     except Exception as e:
         error_msg = f"在文件加载或解析阶段发生错误: {e}"
@@ -263,10 +264,11 @@ def fold_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
     state['analysis_parameters'] = data_summary
     
     # 运行确定性验证
-    is_ready, issues, recommends = validate_analysis(
+    is_ready, issues, recommends = await asyncio.to_thread(
+        validate_analysis,
         data_summary, 
-        target=target, 
-        treatment=treatment
+        target=target,
+        treatment=treatment,
     )
 
     # 根据验证结果决策
@@ -331,7 +333,7 @@ def fold_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
         }
 
 
-def preprocess_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
+async def preprocess_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
     """
     项目预处理模块:
     1.  从状态(state)中加载 DataFrame 和数据摘要。
@@ -356,13 +358,13 @@ def preprocess_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
         return {"messages": [new_message]}
 
     # 动态生成 DataFrame（从 file_content）
-    df = pd.read_csv(io.StringIO(file_content))
+    df = await asyncio.to_thread(pd.read_csv, io.StringIO(file_content))
     logging.info(f"从 file_content 重新生成 DataFrame，shape: {df.shape}")
 
     # 生成可视化图表 
     visualizations = {}
     try:
-        visualizations = generate_visualizations(df, analysis_parameters)
+        visualizations = await asyncio.to_thread(generate_visualizations, df, analysis_parameters)
         state["visualizations"] = visualizations
         logging.info("数据可视化图表已成功生成。")
     
@@ -401,7 +403,7 @@ def preprocess_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
     logging.info("正在调用LLM生成数据分析总结...")
     
     
-    preprocess_summary = runnable.invoke({
+    preprocess_summary = await runnable.ainvoke({
         "data_summary": json.dumps(analysis_parameters, indent=2, ensure_ascii=False),
         "system_role": data_prompt()
     })
@@ -429,7 +431,7 @@ from Agent.tool_node.rag_query_task import rag_query_task
 from Agent.tool_node.rag_questions import get_rag_questions
 
 
-def execute_tools_node(state: CausalChatState, mcp_session: ClientSession, llm: ChatOpenAI) -> dict:
+async def execute_tools_node(state: CausalChatState, mcp_session: ClientSession, llm: ChatOpenAI) -> dict:
     """
     执行工具模块。
     输入：mcp模块
@@ -444,17 +446,13 @@ def execute_tools_node(state: CausalChatState, mcp_session: ClientSession, llm: 
     # 并行执行任务并等待结果 
     logging.info(" 开始并行执行因果分析和RAG查询 ")
 
-    rag_question_task = get_rag_questions(state, llm, num_questions=2)
+    rag_question_future = get_rag_questions(state, llm, num_questions=2)
+    causal_future = causal_analysis_task(file_content, mcp_session, llm, state)
 
-    causal_task = causal_analysis_task(file_content, mcp_session, llm, state)
+    rag_questions = await rag_question_future
+    rag_future = rag_query_task(rag_questions)
 
-    rag_questions = rag_question_task.result()
-
-    rag_task = rag_query_task(rag_questions)    
-    
-    causal_task_result = causal_task.result()
-
-    rag_task_result = rag_task.result()
+    causal_task_result, rag_task_result = await asyncio.gather(causal_future, rag_future)
     
     logging.info(" 因果分析和RAG查询均已完成 ")
     
@@ -500,7 +498,7 @@ from Agent.Postprocessing.cycles_check.fix_cycles import fix_cycles_with_llm
 # 边评估模块
 from Agent.Postprocessing.evaluate_edge.evaluate_edge_llm import evaluate_edges_with_llm
 
-def postprocess_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
+async def postprocess_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
     """
     后处理模块：
     1. 提取并验证因果图结构
@@ -539,7 +537,8 @@ def postprocess_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
         has_cycle, cycles = detect_cycles(working_matrix, node_names)
         if has_cycle:
             logging.info(f"检测到 {len(cycles)} 个环路，开始LLM辅助修正...")
-            working_matrix = fix_cycles_with_llm(
+            working_matrix = await asyncio.to_thread(
+                fix_cycles_with_llm,
                 working_matrix, 
                 cycles, 
                 node_names,
@@ -565,7 +564,7 @@ def postprocess_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
         edge_evaluations = {}
         if critical_edges:
             logging.info(f"识别到 {len(critical_edges)} 条关键边，开始LLM评估...")
-            edge_evaluations = evaluate_edges_with_llm(critical_edges, state, llm)
+            edge_evaluations = await asyncio.to_thread(evaluate_edges_with_llm, critical_edges, state, llm)
         else:
             logging.info("未识别到需要评估的关键边")
         
@@ -619,7 +618,7 @@ def postprocess_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
 
 ## 调用元数据
 from Agent.Report.Metadata_sum import metadata_summary, metadata_mapping
-def report_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
+async def report_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
     """
     报告模块：
     主要是对所有的参数生成一份报告
@@ -674,8 +673,16 @@ def report_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
     # 格式化字符串输出
     runnable = prompt | llm | StrOutputParser()
     
-    meta_data = metadata_summary(state.get("analysis_parameters", {}), state.get("visualizations", {}))
-    mapping_data = metadata_mapping(meta_data, state.get("visualizations", {}))
+    meta_data = await asyncio.to_thread(
+        metadata_summary,
+        state.get("analysis_parameters", {}),
+        state.get("visualizations", {}),
+    )
+    mapping_data = await asyncio.to_thread(
+        metadata_mapping,
+        meta_data,
+        state.get("visualizations", {}),
+    )
     
     # 在invoke时，将模板变量和消息历史分开传入
     knowledge_summary = format_rag_summary_for_prompt(
@@ -684,7 +691,7 @@ def report_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
         include_evidence=True
     )
 
-    response = runnable.invoke({
+    response = await runnable.ainvoke({
         "messages": state["messages"],
         "preprocess_meta_data": meta_data,
         "preprocess_summary": state.get("preprocess_summary", {}),
@@ -722,7 +729,7 @@ def report_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
         "messages": [report_complete_message]
     }
 
-def normal_chat_node(state: CausalChatState,llm: ChatOpenAI) -> dict:
+async def normal_chat_node(state: CausalChatState,llm: ChatOpenAI) -> dict:
     """
     Represents "正常问答".
     This is for when the agent determines it's a simple chat conversation.
@@ -743,13 +750,13 @@ def normal_chat_node(state: CausalChatState,llm: ChatOpenAI) -> dict:
         ]
     )
     runnable = prompt | llm | StrOutputParser()
-    response = runnable.invoke({
+    response = await runnable.ainvoke({
         "messages": state["messages"],
     })
     # 只返回新消息
     return {"messages": [AIMessage(content=response, name="normal_chat")]}
 
-def inquiry_answer_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
+async def inquiry_answer_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
     """
     根据报告追问用户的问题
     """
@@ -781,7 +788,7 @@ def inquiry_answer_node(state: CausalChatState, llm: ChatOpenAI) -> dict:
         include_evidence=True
     )
 
-    response = runnable.invoke({
+    response = await runnable.ainvoke({
         "messages": state["messages"],
         "causal_analysis_result": state.get("causal_analysis_result", {}),
         "knowledge_base_result": knowledge_summary,

--- a/Agent/knowledge_base/build_knowledge.py
+++ b/Agent/knowledge_base/build_knowledge.py
@@ -2,8 +2,8 @@ import os
 import sys
 from typing import Dict, List
 
-from langchain.docstore.document import Document
-from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_core.documents import Document
+from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain_chroma import Chroma
 from langchain_community.document_loaders import PyMuPDFLoader, PyPDFLoader
 from langchain_huggingface import HuggingFaceEmbeddings

--- a/Agent/knowledge_base/query_rag.py
+++ b/Agent/knowledge_base/query_rag.py
@@ -53,7 +53,7 @@ def _get_llm() -> ChatOpenAI:
     return ChatOpenAI(
         api_key=settings.API_KEY,
         base_url=settings.BASE_URL,
-        model_name=settings.MODEL,
+        model=settings.MODEL,
     )
 
 

--- a/Agent/tool_node/causal_analysis_task.py
+++ b/Agent/tool_node/causal_analysis_task.py
@@ -3,6 +3,7 @@
 实现 LLM 动态选择 MCP 工具的机制
 """
 from langgraph.func import task
+import asyncio
 import logging
 from mcp import ClientSession
 from typing import List, Dict, Optional
@@ -12,6 +13,9 @@ from langchain_openai import ChatOpenAI
 from Agent.causal_agent.state import CausalChatState
 from langchain_core.output_parsers import JsonOutputParser
 from langchain_core.prompts import ChatPromptTemplate
+
+MCP_LIST_TOOLS_TIMEOUT_SECONDS = 30
+MCP_CALL_TOOL_TIMEOUT_SECONDS = 240
 
 class ToolSelection(BaseModel):
     """LLM 工具选择的结果模型"""
@@ -56,7 +60,10 @@ async def select_causal_tool(
         选中的工具名称，如果选择失败返回 None
     """
     logging.info("正在获取 MCP 可用工具列表...")
-    tools_response = await mcp_session.list_tools()
+    tools_response = await asyncio.wait_for(
+        mcp_session.list_tools(),
+        timeout=MCP_LIST_TOOLS_TIMEOUT_SECONDS,
+    )
     causal_tools = tools_response.tools
 
     if not causal_tools:
@@ -92,7 +99,7 @@ async def select_causal_tool(
 
     try:
         runnable = prompt | llm | JsonOutputParser()
-        response = runnable.invoke({
+        response = await runnable.ainvoke({
             "tools_description": tools_description,
             "messages": state["messages"],
             "data_summary": json.dumps(state.get("analysis_parameters", {}), indent=2, ensure_ascii=False),
@@ -152,9 +159,12 @@ async def causal_analysis_task(
 
         logging.info(f"使用工具: {selected_tool}")
 
-        tool_response = await mcp_session.call_tool(
-            selected_tool,
-            {"csv_data": file_content}
+        tool_response = await asyncio.wait_for(
+            mcp_session.call_tool(
+                selected_tool,
+                {"csv_data": file_content},
+            ),
+            timeout=MCP_CALL_TOOL_TIMEOUT_SECONDS,
         )
 
         result = json.loads(tool_response.content[0].text)
@@ -163,6 +173,9 @@ async def causal_analysis_task(
         logging.info(f"Task: MCP 因果分析完成，使用工具: {selected_tool}")
         return result
 
+    except json.JSONDecodeError as e:
+        logging.error(f"Task: MCP 返回结果不是有效 JSON: {e}")
+        return {"success": False, "message": f"MCP 返回结果不是有效 JSON: {e}"}
     except Exception as e:
-        logging.error(f"Task: MCP 调用失败: {e}")
-        return {"success": False, "message": str(e)}
+        logging.error(f"Task: MCP 调用失败，将交给节点 retry/error_handler 处理: {e}")
+        raise

--- a/Agent/tool_node/rag_query_task.py
+++ b/Agent/tool_node/rag_query_task.py
@@ -2,6 +2,7 @@
 @task封装的RAG查询任务
 """
 import logging
+import asyncio
 from typing import Dict, List, Union
 
 from langgraph.func import task
@@ -10,7 +11,7 @@ from Agent.knowledge_base.query_rag import get_rag_response
 
 
 @task
-def rag_query_task(questions: List[Union[str, Dict]]) -> Dict:
+async def rag_query_task(questions: List[Union[str, Dict]]) -> Dict:
     """
     Task: 查询知识库（RAG）
 
@@ -22,7 +23,7 @@ def rag_query_task(questions: List[Union[str, Dict]]) -> Dict:
     """
     logging.info("正在启动RAG查询任务...")
     try:
-        rag_response = get_rag_response(questions)
+        rag_response = await asyncio.to_thread(get_rag_response, questions)
         logging.info("Task: 知识库查询完成")
         return rag_response
     

--- a/Agent/tool_node/rag_questions.py
+++ b/Agent/tool_node/rag_questions.py
@@ -44,11 +44,16 @@ def _format_messages(messages: List[BaseMessage], max_messages: int = 6) -> str:
 
 
 @task
-def get_rag_questions(
+async def get_rag_questions(
     state: CausalChatState,
     llm: ChatOpenAI,
     num_questions: int,
 ) -> List[Dict]:
+    """
+    生成结构化 RAG 查询问题。
+
+    结构化输出失败时返回兜底问题，避免问题生成失败直接终止整条 Agent 链路。
+    """
     logging.info("正在启动 RAG 问题生成任务...")
     try:
         rag_prompt = ChatPromptTemplate.from_messages(
@@ -89,7 +94,7 @@ system role: {system_role}
         question_generator_runnable = rag_prompt | llm | JsonOutputParser()
         logging.info("正在调用LLM生成结构化RAG查询问题...")
 
-        llm_output = question_generator_runnable.invoke(
+        llm_output = await question_generator_runnable.ainvoke(
             {
                 "messages": _format_messages(state["messages"]),
                 "data_summary": json.dumps(state.get("analysis_parameters", {}), indent=2, ensure_ascii=False),

--- a/Database/mysql_checkpointer.py
+++ b/Database/mysql_checkpointer.py
@@ -10,6 +10,7 @@ from langgraph.checkpoint.base import (
     Checkpoint,
     CheckpointMetadata,
     CheckpointTuple,
+    WRITES_IDX_MAP,
 )
 from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 import mysql.connector
@@ -21,6 +22,8 @@ from app.db import get_read_connection, get_write_connection
 
 # 配置日志
 logger = logging.getLogger(__name__)
+
+_SERDE_PREFIX = b"LGST1"
 
 class MySQLSaver(BaseCheckpointSaver):
     """
@@ -70,6 +73,49 @@ class MySQLSaver(BaseCheckpointSaver):
         self.connection_config = connection_config
         
         logger.info("MySQLSaver 初始化完成")
+
+    def _serialize_blob(self, value: Any) -> bytes:
+        """
+        使用新版 LangGraph typed serializer 序列化值。
+
+        langgraph-checkpoint 4.x 的 JsonPlusSerializer 不再暴露 dumps/loads，
+        而是使用 dumps_typed/loads_typed 返回 `(type, bytes)`。当前数据库
+        schema 只有一个 LONGBLOB 字段，因此这里把 type 头和 payload 合并
+        存储，避免为序列化类型新增 schema 字段。
+        """
+        value_type, payload = self.serde.dumps_typed(value)
+        type_bytes = value_type.encode("utf-8")
+        if len(type_bytes) > 65535:
+            raise ValueError(f"序列化类型名过长: {value_type}")
+        return _SERDE_PREFIX + len(type_bytes).to_bytes(2, "big") + type_bytes + payload
+
+    def _deserialize_blob(self, blob: Any) -> Any:
+        """
+        反序列化 checkpoint / pending write blob。
+
+        新写入的数据带有 `_SERDE_PREFIX` 头；旧数据没有头时，按新版
+        JsonPlusSerializer 支持的 msgpack / pickle / json 顺序做兼容读取。
+        """
+        if blob is None:
+            return None
+
+        data = bytes(blob)
+        if data.startswith(_SERDE_PREFIX):
+            type_len_start = len(_SERDE_PREFIX)
+            type_len_end = type_len_start + 2
+            type_len = int.from_bytes(data[type_len_start:type_len_end], "big")
+            value_type = data[type_len_end:type_len_end + type_len].decode("utf-8")
+            payload = data[type_len_end + type_len:]
+            return self.serde.loads_typed((value_type, payload))
+
+        last_error: Exception | None = None
+        for value_type in ("msgpack", "pickle", "json", "bytes"):
+            try:
+                return self.serde.loads_typed((value_type, data))
+            except Exception as exc:
+                last_error = exc
+
+        raise ValueError(f"无法反序列化 checkpoint blob: {last_error}") from last_error
     
     @contextmanager
     def _get_connection(self):
@@ -157,10 +203,10 @@ class MySQLSaver(BaseCheckpointSaver):
         )
         
         # 序列化 checkpoint 和 metadata
-        # 使用 serde.dumps() 将 Python 对象转为 bytes
+        # 使用 LangGraph typed serializer 将 Python 对象转为 bytes
         # 这样可以安全存储到 LONGBLOB 字段中
         try:
-            checkpoint_blob = self.serde.dumps(checkpoint)
+            checkpoint_blob = self._serialize_blob(checkpoint)
             metadata_json = json.dumps(metadata, ensure_ascii=False)
         except Exception as e:
             logger.error(f"序列化 checkpoint 失败: {e}")
@@ -295,7 +341,7 @@ class MySQLSaver(BaseCheckpointSaver):
             #  反序列化 checkpoint 数据 
             try:
                 # 从 LONGBLOB 读取 bytes，反序列化为 Python 对象
-                checkpoint_data = self.serde.loads(bytes(row["checkpoint"]))
+                checkpoint_data = self._deserialize_blob(row["checkpoint"])
                 
                 # 解析 JSON 元数据
                 metadata = json.loads(row["metadata_data"]) if row["metadata_data"] else {}
@@ -320,7 +366,7 @@ class MySQLSaver(BaseCheckpointSaver):
             pending_writes = []
             for write_row in write_rows:
                 try:
-                    value = self.serde.loads(bytes(write_row["value"])) if write_row["value"] else None
+                    value = self._deserialize_blob(write_row["value"]) if write_row["value"] else None
                     pending_writes.append((
                         write_row["task_id"],
                         write_row["channel"],
@@ -359,7 +405,7 @@ class MySQLSaver(BaseCheckpointSaver):
     
     def list(
         self,
-        config: Dict[str, Any],
+        config: Optional[Dict[str, Any]],
         *,
         filter: Optional[Dict[str, Any]] = None,
         before: Optional[Dict[str, Any]] = None,
@@ -371,7 +417,7 @@ class MySQLSaver(BaseCheckpointSaver):
         这个方法用于 graph.get_state_history(config) API
         
         Args:
-            config: {"configurable": {"thread_id": "..."}}
+            config: {"configurable": {"thread_id": "..."}}；若为 None，则列出所有 thread。
             filter: 过滤条件（暂未使用）
             before: 获取某个 checkpoint 之前的历史（暂未使用）
             limit: 限制返回数量
@@ -386,10 +432,11 @@ class MySQLSaver(BaseCheckpointSaver):
             # history[1] 是第2新的
             # ...
         """
-        thread_id = config["configurable"]["thread_id"]
-        checkpoint_ns = config["configurable"].get("checkpoint_ns", "")
+        configurable = (config or {}).get("configurable", {})
+        thread_id = configurable.get("thread_id")
+        checkpoint_ns = configurable.get("checkpoint_ns", "")
         
-        logger.info(f"列出 thread {thread_id} 的 checkpoint 历史")
+        logger.info(f"列出 checkpoint 历史: thread_id={thread_id or '*'}")
         
         with get_read_connection(consistency="strong") as conn:
             cursor = conn.cursor(dictionary=True)
@@ -405,10 +452,14 @@ class MySQLSaver(BaseCheckpointSaver):
                     metadata_data,
                     created_at
                 FROM checkpoints
-                WHERE thread_id = %s AND checkpoint_ns = %s
-                ORDER BY created_at DESC
             """
-            params = [thread_id, checkpoint_ns]
+            params = []
+
+            if thread_id:
+                query += " WHERE thread_id = %s AND checkpoint_ns = %s"
+                params.extend([thread_id, checkpoint_ns])
+
+            query += " ORDER BY created_at DESC"
             
             # 如果指定了 limit，添加到查询
             if limit:
@@ -421,7 +472,7 @@ class MySQLSaver(BaseCheckpointSaver):
             for row in cursor:
                 try:
                     # 反序列化
-                    checkpoint_data = self.serde.loads(bytes(row["checkpoint"]))
+                    checkpoint_data = self._deserialize_blob(row["checkpoint"])
                     metadata = json.loads(row["metadata_data"]) if row["metadata_data"] else {}
                     
                     # 构建 parent_config
@@ -429,8 +480,8 @@ class MySQLSaver(BaseCheckpointSaver):
                     if row["parent_checkpoint_id"]:
                         parent_config = {
                             "configurable": {
-                                "thread_id": thread_id,
-                                "checkpoint_ns": checkpoint_ns,
+                                "thread_id": row["thread_id"],
+                                "checkpoint_ns": row["checkpoint_ns"],
                                 "checkpoint_id": row["parent_checkpoint_id"],
                             }
                         }
@@ -439,8 +490,8 @@ class MySQLSaver(BaseCheckpointSaver):
                     yield CheckpointTuple(
                         config={
                             "configurable": {
-                                "thread_id": thread_id,
-                                "checkpoint_ns": checkpoint_ns,
+                                "thread_id": row["thread_id"],
+                                "checkpoint_ns": row["checkpoint_ns"],
                                 "checkpoint_id": row["checkpoint_id"],
                             }
                         },
@@ -499,38 +550,37 @@ class MySQLSaver(BaseCheckpointSaver):
             cursor = conn.cursor()
             
             # 遍历所有写操作
+            saved_count = 0
             for idx, (channel, value) in enumerate(writes):
-                try:
-                    # 序列化值
-                    value_blob = self.serde.dumps(value)
-                    
-                    # 插入到 checkpoint_writes 表
-                    cursor.execute("""
-                        INSERT INTO checkpoint_writes (
-                            thread_id,
-                            checkpoint_ns,
-                            checkpoint_id,
-                            task_id,
-                            idx,
-                            channel,
-                            value
-                        ) VALUES (%s, %s, %s, %s, %s, %s, %s)
-                    """, (
+                # 特殊写入（error/scheduled/interrupt/resume）使用 LangGraph 官方
+                # 固定负数 idx，普通 channel 保留原顺序 idx。
+                write_idx = WRITES_IDX_MAP.get(channel, idx)
+                value_blob = self._serialize_blob(value)
+
+                # 插入到 checkpoint_writes 表
+                cursor.execute("""
+                    INSERT INTO checkpoint_writes (
                         thread_id,
                         checkpoint_ns,
                         checkpoint_id,
                         task_id,
-                        idx,           # 写操作的索引（保持顺序）
-                        channel,       # State 中的字段名
-                        value_blob     # 序列化后的值
-                    ))
-                
-                except Exception as e:
-                    logger.error(f"保存 pending write 失败 (channel={channel}): {e}")
-                    # 继续处理其他写操作
+                        idx,
+                        channel,
+                        value
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s)
+                """, (
+                    thread_id,
+                    checkpoint_ns,
+                    checkpoint_id,
+                    task_id,
+                    write_idx,      # 写操作的索引（保持顺序）
+                    channel,        # State 中的字段名
+                    value_blob      # 序列化后的值
+                ))
+                saved_count += 1
             
             conn.commit()
-            logger.info(f"{len(writes)} 个 pending writes 保存成功")
+            logger.info(f"{saved_count} 个 pending writes 保存成功")
 
     # ===== 异步方法实现（用于 ainvoke/astream） =====
     
@@ -575,7 +625,7 @@ class MySQLSaver(BaseCheckpointSaver):
     
     async def alist(
         self,
-        config: Dict[str, Any],
+        config: Optional[Dict[str, Any]],
         *,
         filter: Optional[Dict[str, Any]] = None,
         before: Optional[Dict[str, Any]] = None,
@@ -585,7 +635,7 @@ class MySQLSaver(BaseCheckpointSaver):
         异步列出 checkpoint 历史
         
         Args:
-            config: 配置字典
+            config: 配置字典；若为 None，则列出所有 thread。
             filter: 过滤条件
             before: 获取某个 checkpoint 之前的历史
             limit: 限制返回数量

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,7 @@ RUN apt-get update && apt-get install -y \
 
 # 先安装基础依赖（很少变化）
 COPY requirements-base.txt .
-RUN pip install --no-cache-dir -r requirements-base.txt \
-    --trusted-host pypi.tuna.tsinghua.edu.cn \
-    -i https://pypi.tuna.tsinghua.edu.cn/simple
+RUN pip install --no-cache-dir -r requirements-base.txt
 
 # 再安装所有依赖（包括新增的）
 COPY requirements.txt .

--- a/README.md
+++ b/README.md
@@ -742,3 +742,7 @@ python Run_causal.py
 2026.5.26
 - 【内容新增】
   本次改造是在不改变现有架构的前提下，引入 LangGraph 1.2 的节点级容错能力。已完成依赖升级门禁、LangChain v1 兼容迁移、节点 async 化、MCP/RAG task 异步化，以及基于 `retry_policy / timeout / error_handler` 的集中容错策略。
+  
+- 【bug修复】
+  - 升级到 langgraph-checkpoint==4.1.1 后，JsonPlusSerializer 不再有 dumps/loads，新版接口是 dumps_typed/loads_typed。
+  - 修复前端报告占位符问题

--- a/README.md
+++ b/README.md
@@ -737,3 +737,8 @@ python Run_causal.py
   - 后台 worker 以 slot 为单位持有独立 MCP session 和 Agent graph，避免 Web 进程阻塞。
   - 同一 `user_id + session_id` 的并发任务通过唯一约束兜底，防止重复执行。
   - 旧接口 `POST /api/send_stream` 已转为迁移提示，前端改走 `POST /api/agent/jobs` 与 SSE 订阅。
+
+---
+2026.5.26
+- 【内容新增】
+  本次改造是在不改变现有架构的前提下，引入 LangGraph 1.2 的节点级容错能力。已完成依赖升级门禁、LangChain v1 兼容迁移、节点 async 化、MCP/RAG task 异步化，以及基于 `retry_policy / timeout / error_handler` 的集中容错策略。

--- a/app/agent/core.py
+++ b/app/agent/core.py
@@ -18,7 +18,7 @@ from typing import Any, Type, List
 from pydantic import BaseModel, create_model
 from langgraph.types import Command 
 from Agent.causal_agent.state import CausalChatState
-from Agent.Report.Metadata_sum import replace_placeholders
+from app.chat.response_storage import render_summary_for_display
 
 ## die manager
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -422,11 +422,12 @@ def process_final_result(final_state_data):
                     visualization_mapping = final_state_data["visualization_mapping"]
                     if visualization_mapping:  # 确保不是空字典
                         # 保存映射数据（用于数据库存储）
+                        result["raw_summary"] = result["summary"]
                         result["visualization_mapping"] = visualization_mapping
                         logging.info(f"包含 {len(visualization_mapping)} 个可视化图表")
 
                         # 替换 summary 中的占位符为真实图表
-                        result["summary"] = replace_placeholders(
+                        result["summary"] = render_summary_for_display(
                             result["summary"],
                             visualization_mapping
                         )

--- a/app/chat/response_storage.py
+++ b/app/chat/response_storage.py
@@ -1,0 +1,55 @@
+"""
+app.chat.response_storage - AI 响应展示与持久化格式转换。
+"""
+
+import json
+from typing import Any
+
+from Agent.Report.Metadata_sum import replace_placeholders
+
+
+def render_summary_for_display(summary: str | None, visualization_mapping: dict | None) -> str | None:
+    """把原始报告占位符渲染成图片标签，并避免已经渲染过的 HTML 被二次替换。"""
+    if not summary or not visualization_mapping:
+        return summary
+
+    if "data:image/" in summary or "<img" in summary.lower():
+        return summary
+
+    return replace_placeholders(summary, visualization_mapping)
+
+
+def prepare_ai_response_for_storage(ai_response: Any) -> tuple[str, list[dict[str, str]]]:
+    """把 AI 响应转换为聊天主表内容和附件列表，报告正文入库时保留原始占位符。"""
+    attachment_to_save: list[dict[str, str]] = []
+
+    if isinstance(ai_response, dict):
+        raw_summary = ai_response.get("raw_summary") or ai_response.get("summary")
+        ai_content = raw_summary
+
+        if ai_content is None:
+            ai_content = json.dumps(ai_response, ensure_ascii=False)
+
+        if ai_response.get("type") == "causal_graph" and "data" in ai_response:
+            persisted_response = dict(ai_response)
+            if raw_summary is not None:
+                persisted_response["summary"] = raw_summary
+            persisted_response.pop("raw_summary", None)
+            persisted_response.pop("visualization_mapping", None)
+            attachment_to_save.append({
+                "type": "causal_graph",
+                "content": json.dumps(persisted_response, ensure_ascii=False),
+            })
+
+        if ai_response.get("visualization_mapping"):
+            attachment_to_save.append({
+                "type": "visualization",
+                "content": json.dumps(ai_response["visualization_mapping"], ensure_ascii=False),
+            })
+
+        return ai_content, attachment_to_save
+
+    if isinstance(ai_response, str):
+        return ai_response, attachment_to_save
+
+    return json.dumps(ai_response, ensure_ascii=False), attachment_to_save

--- a/app/chat/routes.py
+++ b/app/chat/routes.py
@@ -5,7 +5,7 @@ from flask import Blueprint, request, jsonify, session
 from app.auth.session_guard import get_current_session_user
 import logging
 import json
-from Agent.Report.Metadata_sum import replace_placeholders
+from app.chat.response_storage import render_summary_for_display
 
 chat_bp = Blueprint('chat', __name__, url_prefix='/api')
 import uuid
@@ -154,14 +154,17 @@ def load_session_content():
                         message_content = causal_graph_data
 
                         if visualization_mapping and "summary" in message_content:
-                            message_content["summary"] = replace_placeholders(message_content["summary"], visualization_mapping)
+                            message_content["summary"] = render_summary_for_display(
+                                message_content["summary"],
+                                visualization_mapping,
+                            )
 
                         messages.append({"sender": "ai", "text": message_content})
                     else:
                         message_text = row["content"]
 
                         if visualization_mapping:
-                            message_text = replace_placeholders(message_text, visualization_mapping)
+                            message_text = render_summary_for_display(message_text, visualization_mapping)
 
                         messages.append({"sender": "ai", "text": message_text})
 

--- a/app/chat/services.py
+++ b/app/chat/services.py
@@ -5,9 +5,9 @@ app.chat.services - 聊天服务
 - 获取聊天记录
 '''
 from app.db import get_read_connection, get_write_connection
+from app.chat.response_storage import prepare_ai_response_for_storage
 import mysql.connector
 import logging
-import json
 from datetime import datetime
 def get_chat_history(session_id: str, user_id: int, limit: int) -> list:
     """从数据库获取指定会话的最近聊天记录。"""
@@ -86,40 +86,7 @@ def save_chat(user_id, session_id, user_msg, ai_response):
             cursor.execute(sql_user, (session_id, user_id, user_msg, timestamp_dt))
             
             # 保存AI消息
-            ai_content = ""
-            attachment_content = None
-            attachment_type = 'other'
-            attachment_to_save = []
-
-            if isinstance(ai_response, dict):
-                # 确保 summary 键存在且不为 None
-                ai_content = ai_response.get('summary')
-                
-                if ai_content is None:
-                    # 如果 summary 为空，将整个响应序列化为字符串作为备用
-                    ai_content = json.dumps(ai_response, ensure_ascii=False)
-                    logging.warning(f"AI响应中 summary 为空，已将整个响应序列化为字符串作为备用。")
-                
-                if ai_response.get('type') == 'causal_graph' and 'data' in ai_response:
-                    attachment_type = 'causal_graph'
-                    attachment_content = json.dumps(ai_response, ensure_ascii=False) # 保存完整响应
-                    attachment_to_save.append({
-                        "type": attachment_type,
-                        "content": attachment_content
-                    })
-                
-                if ai_response.get('visualization_mapping'):
-                    attachment_type = 'visualization'
-                    attachment_content = json.dumps(ai_response.get('visualization_mapping'), ensure_ascii=False)
-                    attachment_to_save.append({
-                        "type": attachment_type,
-                        "content": attachment_content
-                    })
-
-            elif isinstance(ai_response, str):
-                ai_content = ai_response
-            else:
-                ai_content = json.dumps(ai_response, ensure_ascii=False)
+            ai_content, attachment_to_save = prepare_ai_response_for_storage(ai_response)
             
             # 处理数据库保存格式
             sql_ai = """

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ mysql-connector-python==9.3.0
 proxy_tools==0.1.0
 pycparser==2.22
 pydantic==2.11.4
-pydantic-settings==2.9.1
+pydantic-settings==2.10.1
 pydantic_core==2.33.2
 python-dotenv==1.1.0
 python-multipart==0.0.20
@@ -42,26 +42,26 @@ wincertstore==0.2
 
 # --- LangChain & RAG Dependencies ---
 
-langchain==0.3.26
-langchain-core==0.3.68
-langchain-openai==0.3.27
-langchain_community==0.3.27
-langchain-text-splitters==0.3.8
-langgraph==0.6.3
-langgraph-checkpoint==2.1.1
-langgraph-prebuilt==0.6.3
+langchain==1.3.1
+langchain-core==1.4.0
+langchain-openai==1.2.2
+langchain-community==0.4.2
+langchain-text-splitters==1.1.2
+langgraph==1.2.1
+langgraph-checkpoint==4.1.1
+langgraph-prebuilt==1.1.0
 tiktoken==0.7.0
 
 # RAG & 数据处理相关
-chromadb==1.0.13
-langchain-chroma==0.2.4
+chromadb==1.5.9
+langchain-chroma==1.1.0
 
 # sentence-transformers需要torch，使用CPU版本避免下载2GB+的CUDA库
 torch==2.7.1 
 sentence-transformers==3.0.1
 pymupdf==1.24.7
 unstructured==0.14.9
-langchain-huggingface>=0.1.0
+langchain-huggingface==1.2.2
 
 # 数据可视化依赖
 matplotlib>=3.5.0
@@ -73,7 +73,8 @@ pandas>=2.0.0
 networkx>=3.0
 causal-learn>=0.1.3.3
 
-openai>=1.55.3
+openai>=2.26.0,<3.0.0
+requests>=2.32.5,<3.0.0
 
 # 数据库迁移工具
 alembic==1.17.0


### PR DESCRIPTION
2026.5.26
- 【内容新增】
  本次改造是在不改变现有架构的前提下，引入 LangGraph 1.2 的节点级容错能力。已完成依赖升级门禁、LangChain v1 兼容迁移、节点 async 化、MCP/RAG task 异步化，以及基于 `retry_policy / timeout / error_handler` 的集中容错策略。
  
- 【bug修复】
  - 升级到 langgraph-checkpoint==4.1.1 后，JsonPlusSerializer 不再有 dumps/loads，新版接口是 dumps_typed/loads_typed。
  - 修复前端报告占位符问题