### PR TITLE
feat(database):统一数据库初始化入口

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,7 +51,7 @@ MYSQL_REPLICA_MAX_LAG_SECONDS=2
 MYSQL_REPLICA_STATUS_CACHE_SECONDS=2
 MYSQL_QUERY_WARN_MS=500
 
-# LangGraph checkpoint 专用 PostgreSQL。仅 Agent worker、setup 和 cleanup worker 使用。
+# LangGraph checkpoint 专用 PostgreSQL。由统一 bootstrap 初始化，供 Agent worker 和 cleanup worker 使用。
 CHECKPOINT_POSTGRES_HOST=postgres-checkpoint
 CHECKPOINT_POSTGRES_PORT=5432
 CHECKPOINT_POSTGRES_DATABASE=causalagent_checkpoints

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@
 │   └── tool_node/
 ├── Database/               # 数据库初始化与迁移逻辑
 │   ├── database_init.py
+│   ├── bootstrap.py        # MySQL/Alembic/PostgreSQL 统一初始化入口
 │   ├── audit_before_db_upgrade.py
 │   ├── inspection.py       # 数据库看板统一只读检查服务
 │   ├── deep_audit.py       # 手动 deep 数据库事实审计
@@ -127,7 +128,7 @@
 - 管理员 Vue 生产构建默认从 `admin-frontend/dist` 读取；Docker 镜像使用 Node 24 构建阶段，并把产物复制到 `/opt/causalagent-admin`。最终 Python 运行镜像不包含 Node、不启动 Vite、不开放 Node 端口。开发期只有显式设置 `ADMIN_VITE_DEV_SERVER_URL` 时，Flask 在完成页面鉴权后才跳转到 Vite。
 - `admin-frontend/dist/` 是需要随管理员 Vue 源码同步更新并提交的发布产物；根 `.gitignore` 只忽略仓库根目录 `/dist/`。`.dockerignore` 继续排除本地前端产物，因为 Dockerfile 会在 Node 构建阶段从当前源码重新构建并复制到 `/opt/causalagent-admin`。
 - 旧管理员 `db_admin.html`、`db_admin.css`、`db_admin.js` 已在等价测试、真实快照和整版回滚演练通过后移除；管理员页面只使用 Vue 生产构建或显式启用的 Vite 开发服务器，普通用户静态前端不受影响。
-- `Database/database_init.py` 只负责加载环境变量、确保数据库存在并检查连接；业务表结构维护入口是 Alembic，而不是这个脚本。
+- `Database/database_init.py` 只负责加载环境变量、确保 MySQL 数据库存在并检查连接；`Database/bootstrap.py` 负责按顺序编排 MySQL 建库、Alembic migration 和 LangGraph PostgreSQL checkpoint setup；业务表结构维护入口仍是 Alembic，而不是 `database_init.py`。
 - Alembic 迁移目录由 `alembic.ini` 指向 `Database/migrations`；业务 schema 变更应以迁移脚本为准。
 - LangGraph checkpoint 的运行时真相在 PostgreSQL；`Database/checkpoint_setup.py` 使用官方 `AsyncPostgresSaver.setup()` 创建 schema，`Database/checkpoint_cleanup_worker.py` 消费 MySQL `checkpoint_cleanup_outbox` 并调用 `adelete_thread()`。MySQL 只保存 outbox，不再保存 checkpoint 数据。
 - `Database/audit_before_db_upgrade.py` 是旧库添加外键前的 schema-aware preflight，不是新库初始化步骤：仅当相关表已存在、目标外键尚未建立且待执行迁移需要该约束时才做孤立数据扫描；全新空库直接执行 Alembic。
@@ -166,7 +167,7 @@
   - `MYSQL_REPLICA_STATUS_USER` / `MYSQL_REPLICA_STATUS_PASSWORD`：只用于执行 `SHOW REPLICA STATUS`。
   - `MYSQL_REPLICATION_USER` / `MYSQL_REPLICATION_PASSWORD`：只给 MySQL 从库复制通道拉 binlog 用。
   - `MYSQL_USER` / `MYSQL_PASSWORD`：仅作为写/读账号兼容兜底，不承担复制状态检查职责。
-- `docker-compose.yml` 是本地主从加 PostgreSQL checkpoint 开发拓扑，当前包含 `mysql-primary`、`mysql-replica`、`postgres-checkpoint`、`app`、`worker`、`monitor`、`checkpoint-setup`、`checkpoint-cleanup` 八个服务；本轮仍不提供自动故障切换。`docker-compose.replica.yml` 仅保留为旧路径兼容副本。
+- `docker-compose.yml` 是本地主从加 PostgreSQL checkpoint 开发拓扑，当前包含 `mysql-primary`、`mysql-replica`、`postgres-checkpoint`、`db-bootstrap`、`app`、`worker`、`monitor`、`checkpoint-cleanup` 八个服务；`db-bootstrap` 是一次性初始化服务，运行成功后其他运行服务才启动，本轮仍不提供自动故障切换。`docker-compose.replica.yml` 仅保留为旧路径兼容副本。
 - 连接池按 OS 进程计算：`write_pool + read_pool * (1 + replica_count)`，worker slot 共享所在进程的池。默认建连/获取池/管理员锁等待/从库状态缓存分别为 5s/3s/5s/2s；复制状态失效或异常只回退主库，不自动切主。真实容量依据和读写矩阵记录在 `setting/database_governance.md`。
 - Docker 是当前首选开发方式；`docker-compose.yml` 中 `app` 和 `worker` 都会挂载以下知识库目录：
   - `Agent/knowledge_base/models`
@@ -243,29 +244,33 @@ python Run_causal.py
 Docker 主从开发启动（推荐）：
 
 ```bash
-docker-compose -f docker-compose.yml up -d
+docker compose -f docker-compose.yml up -d
 ```
 
 首次启动、空卷重建或数据库环境重建后，推荐按下面顺序执行；全新空库不要先运行 preflight：
 
 ```bash
-docker-compose -f docker-compose.yml run --rm app python Database/database_init.py
-docker-compose -f docker-compose.yml run --rm app alembic upgrade head
+docker compose -f docker-compose.yml up -d
 ```
 
 `.env` 必须提供非空 `CHECKPOINT_POSTGRES_PASSWORD`；Compose 会自动运行
-`checkpoint-setup` 和 `checkpoint-cleanup`。本地等价命令为：
+`db-bootstrap` 和 `checkpoint-cleanup`。本地等价命令为：
 
 ```bash
-python -m Database.checkpoint_setup
+python -m Database.bootstrap
 python -m Database.checkpoint_cleanup_worker
 ```
 
 如果你当前不是在 Docker 里开发，再使用本地等价命令：
 
 ```bash
-python Database/database_init.py
-alembic upgrade head
+python -m Database.bootstrap
+```
+
+如需在不重启运行服务的情况下手动重跑一次性初始化入口，可执行：
+
+```bash
+docker compose -f docker-compose.yml run --rm db-bootstrap
 ```
 
 只有旧库尚未建立目标外键、且即将执行添加这些外键的迁移时，才在 `alembic upgrade head` 前运行 `Database/audit_before_db_upgrade.py`。
@@ -277,6 +282,7 @@ alembic upgrade head
 
 ```text
 Database/database_init.py
+Database/bootstrap.py
 Database/migrations/versions/*
 app/db.py
 相关 SQL 读写代码
@@ -356,7 +362,7 @@ python CausalAgent.py
 
 必须检查：
 
-- `Database/database_init.py` 是否同步
+- `Database/database_init.py` 和 `Database/bootstrap.py` 是否同步
 - 对应 Alembic migration 是否存在且升级/回滚逻辑自洽
 - `app/db.py` 的就绪检查是否需要更新
 - 相关 SQL 是否仍兼容旧数据和空数据场景

--- a/Database/bootstrap.py
+++ b/Database/bootstrap.py
@@ -1,0 +1,73 @@
+"""统一执行 MySQL 和 PostgreSQL 数据库初始化。"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+
+from Database.checkpoint_setup import setup_checkpoint_schema_once
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _project_root() -> Path:
+    """返回仓库根目录，保证从任意当前工作目录执行都能定位 Alembic 配置。"""
+    return Path(__file__).resolve().parents[1]
+
+
+def upgrade_mysql_schema(project_root: Path | None = None) -> None:
+    """使用项目现有 Alembic 迁移将 MySQL schema 升级到当前 head。"""
+    root = project_root or _project_root()
+    alembic_config = Config(str(root / "alembic.ini"))
+    LOGGER.info("开始执行 MySQL Alembic migration")
+    command.upgrade(alembic_config, "head")
+
+
+def setup_postgres_checkpoint_schema() -> None:
+    """执行 LangGraph 官方 PostgreSQL checkpoint schema setup。"""
+    LOGGER.info("开始执行 PostgreSQL checkpoint schema setup")
+    asyncio.run(setup_checkpoint_schema_once())
+
+
+def create_mysql_bootstrap():
+    """延迟加载 MySQL bootstrap，避免仅导入模块时创建日志文件。"""
+    from Database.database_init import DatabaseBootstrap
+
+    return DatabaseBootstrap()
+
+
+def run_bootstrap(project_root: Path | None = None) -> None:
+    """按依赖顺序完成 MySQL 建库、Alembic 迁移和 PostgreSQL setup。"""
+    LOGGER.info("开始执行统一数据库 bootstrap")
+
+    mysql_bootstrap = create_mysql_bootstrap()
+    if not mysql_bootstrap.bootstrap():
+        raise RuntimeError("MySQL 数据库连接检查失败，停止执行后续初始化。")
+
+    upgrade_mysql_schema(project_root)
+    setup_postgres_checkpoint_schema()
+    LOGGER.info("统一数据库 bootstrap 完成")
+
+
+def main() -> int:
+    """命令行入口：python -m Database.bootstrap。"""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        force=True,
+    )
+    try:
+        run_bootstrap()
+    except Exception as exc:
+        LOGGER.error("统一数据库 bootstrap 失败: %s", exc, exc_info=True)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Database/checkpoint_setup.py
+++ b/Database/checkpoint_setup.py
@@ -14,6 +14,11 @@ from Agent.causal_agent.postgres_checkpointer import (
 
 async def _main_async() -> None:
     """等待 PostgreSQL 可用后执行官方幂等 setup。"""
+    await setup_checkpoint_schema_once()
+
+
+async def setup_checkpoint_schema_once() -> None:
+    """执行一次 LangGraph PostgreSQL checkpoint schema 初始化并校验版本。"""
     async with open_checkpoint_pool() as pool:
         await setup_checkpoint_schema(pool)
         await verify_checkpoint_schema(pool)

--- a/Database/database_init.py
+++ b/Database/database_init.py
@@ -121,8 +121,8 @@ def main() -> int:
         return 1
 
     print("\n数据库已存在且连接可用。")
-    print("下一步请执行：")
-    print("  docker-compose -f docker-compose.yml run --rm app alembic upgrade head")
+    print("\n如需完成 MySQL 和 PostgreSQL 的完整初始化，请执行：")
+    print("  python -m Database.bootstrap")
     print("\n说明：业务表结构由 Alembic 迁移维护，本脚本不再创建或修改业务表。")
     return 0
 

--- a/Document/admin/development.md
+++ b/Document/admin/development.md
@@ -26,23 +26,37 @@ npm run build
 python -m app.auth.admin_cli promote <username>
 
 # Docker 运行
-docker-compose -f docker-compose.yml run --rm app python -m app.auth.admin_cli promote <username>
+docker compose -f docker-compose.yml run --rm app python -m app.auth.admin_cli promote <username>
 ```
 
 该命令只做幂等提升，不创建用户，也不负责降级管理员。管理员登录后进入 `/admin/database`。
 
 ## PostgreSQL checkpoint
 
-迁移前请在 `.env` 设置非空的 `CHECKPOINT_POSTGRES_PASSWORD`。Docker 主从拓扑会启动
-`postgres-checkpoint`、一次性 `checkpoint-setup` 和持续运行的
-`checkpoint-cleanup`；本地运行等价命令为：
+迁移前请在 `.env` 设置非空的 `CHECKPOINT_POSTGRES_PASSWORD`。数据库初始化统一由
+`db-bootstrap` 完成，Docker 和本地都调用同一个 Python 入口：
 
 ```bash
-python -m Database.checkpoint_setup
+docker compose -f docker-compose.yml run --rm db-bootstrap
+
+# 本地运行
+python -m Database.bootstrap
+```
+
+该入口按顺序执行 MySQL 建库、Alembic migration 和 LangGraph 官方 PostgreSQL
+checkpoint setup。`checkpoint-cleanup` 仍是持续运行的跨库清理 worker：
+
+```bash
 python -m Database.checkpoint_cleanup_worker
 ```
 
-`alembic upgrade head` 中的 PostgreSQL 迁移会删除 MySQL checkpoint 表和数据；
+如需只检查或重新执行 PostgreSQL checkpoint schema，也可以单独运行：
+
+```bash
+python -m Database.checkpoint_setup
+```
+
+统一 bootstrap 中的 Alembic migration 会删除 MySQL checkpoint 表和数据；
 `alembic downgrade` 只重建空的兼容表结构，不恢复已删除数据。
 由于该迁移合并了两个历史 head，回退时必须指定明确目标 revision，不能使用
 `alembic downgrade -1`；例如回退到 `e4f5a6b7c8d9`。

--- a/README.md
+++ b/README.md
@@ -191,24 +191,24 @@ cp .env.example .env
 
 3. 在项目根目录运行docker-compose
 ```bash
-docker-compose -f docker-compose.yml up -d
+docker compose -f docker-compose.yml up -d
 ```
 
-4. 运行数据库迁移
+`docker compose ... up -d` 会在 app、worker、monitor 和 cleanup worker 启动前，
+自动运行一次性 `db-bootstrap`。它依次执行 MySQL 建库、Alembic migration 和
+LangGraph 官方 PostgreSQL setup。若需要手动重跑该初始化入口，可执行：
+
 ```bash
-docker-compose -f docker-compose.yml run --rm app python Database/database_init.py
-docker-compose -f docker-compose.yml run --rm app alembic upgrade head
+docker compose -f docker-compose.yml run --rm db-bootstrap
 ```
 
-PostgreSQL checkpoint 使用独立服务。请先在 `.env` 设置非空的
-`CHECKPOINT_POSTGRES_PASSWORD`；`docker-compose ... up -d` 会自动运行一次
-`checkpoint-setup` 创建官方 LangGraph schema，并启动独立的
-`checkpoint-cleanup` worker。
+请先在 `.env` 设置非空的 `CHECKPOINT_POSTGRES_PASSWORD`。
+`checkpoint-cleanup` 仍是独立的常驻 worker，用于消费跨库清理 outbox。
 
 全新空库不需要运行升级前审计。只有旧库尚未建立目标外键、且即将执行添加这些外键的迁移时，才先运行：
 
 ```bash
-docker-compose -f docker-compose.yml run --rm app python Database/audit_before_db_upgrade.py
+docker compose -f docker-compose.yml run --rm app python Database/audit_before_db_upgrade.py
 ```
 
 > [!IMPORTANT]
@@ -241,7 +241,7 @@ docker-compose -f docker-compose.yml run --rm app python Database/audit_before_d
 
 ```bash
 # Docker 运行
-docker-compose -f docker-compose.yml run --rm app python -m app.auth.admin_cli promote <username>
+docker compose -f docker-compose.yml run --rm app python -m app.auth.admin_cli promote <username>
 ```
 
 管理员系统的部署、开发、API、安全边界和测试说明统一放在 [`Document/admin/`](Document/admin/README.md)。其中：
@@ -366,7 +366,8 @@ docker compose -f docker-compose.test.yml run --rm unit-test sh
 │   │   └── models/         # 嵌入模型
 │   └── tool_node/          # MCP 工具节点封装（task、rag 调用等）
 ├── Database/               # 数据库初始化与迁移逻辑
-│   ├── database_init.py    # 数据库初始化引导脚本
+│   ├── database_init.py    # MySQL 数据库存在性与连接引导
+│   ├── bootstrap.py        # MySQL/Alembic/PostgreSQL 统一初始化入口
 │   ├── audit_before_db_upgrade.py # 数据库生产化升级前审计
 │   ├── inspection.py       # 管理员看板统一只读检查服务
 │   ├── deep_audit.py       # 手动 deep 数据库事实审计

--- a/README/开发日志.md
+++ b/README/开发日志.md
@@ -468,3 +468,10 @@
 - 【工程规范】
   - 新增 GitHub Issue Form 模板，统一收集背景、问题描述、预期结果、复现步骤、验收标准和环境信息。
   - 除附件外的 Issue 字段启用 GitHub 原生必填校验，不增加空格或 `...` 等内容限制；普通贡献者不能选择空白 Issue。
+
+---
+2026.8.2
+- 【数据库初始化入口统一】
+  - 新增 `python -m Database.bootstrap`，按 MySQL 建库、Alembic migration、LangGraph PostgreSQL checkpoint setup 的顺序执行一次性初始化。
+  - 开发 Compose 将初始化入口收敛为一次性的 `db-bootstrap`，app、worker、monitor 和 cleanup worker 都等待统一 bootstrap 成功后启动。
+  - 保留 `Database/checkpoint_setup.py` 作为底层独立命令，`checkpoint-cleanup` 继续承担运行期跨数据库清理职责。

--- a/README_EN.md
+++ b/README_EN.md
@@ -153,8 +153,12 @@ Here is a brief guide. For more detailed, Chinese step-by-step instructions (inc
 3. Start the services:
 
    ```bash
-   docker-compose up -d
+   docker compose up -d
    ```
+
+   The one-shot `db-bootstrap` service initializes the MySQL schema through
+   Alembic and initializes the LangGraph PostgreSQL checkpoint schema before
+   the application services start.
 
 > [!IMPORTANT]
 > The knowledge base is still being built, so RAG-based query features are temporarily limited.
@@ -170,11 +174,10 @@ Here is a brief guide. For more detailed, Chinese step-by-step instructions (inc
    ```
 
 4. Create a `.env` file in the project root (same fields as in the Docker section above).
-5. Initialize the database and run Alembic migrations:
+5. Run the unified database bootstrap:
 
    ```bash
-   python Database/database_init.py
-   alembic upgrade head
+   python -m Database.bootstrap
    ```
 
 6. Start the backend service:

--- a/app/db.py
+++ b/app/db.py
@@ -340,7 +340,7 @@ def check_database_readiness():
             if missing_tables:
                 error_msg = (
                     f"数据库表缺失: {sorted(missing_tables)}。"
-                    "请先运行 'python Database/database_init.py' 并执行 'alembic upgrade head'。"
+                    "请先运行 'python -m Database.bootstrap'。"
                 )
                 logging.error(error_msg)
                 raise RuntimeError(error_msg)
@@ -358,7 +358,7 @@ def check_database_readiness():
             if cursor.fetchone() is None:
                 error_msg = (
                     "数据库关键字段缺失: users.role。"
-                    "请先执行 'alembic upgrade head'。"
+                    "请先运行 'python -m Database.bootstrap'。"
                 )
                 logging.error(error_msg)
                 raise RuntimeError(error_msg)
@@ -382,7 +382,7 @@ def check_database_readiness():
                 error_msg = (
                     "数据库关键字段缺失: "
                     f"{sorted(f'users.{name}' for name in missing_security_columns)}。"
-                    "请先执行 'alembic upgrade head'。"
+                    "请先运行 'python -m Database.bootstrap'。"
                 )
                 logging.error(error_msg)
                 raise RuntimeError(error_msg)
@@ -419,7 +419,7 @@ def check_database_readiness():
                 error_msg = (
                     "数据库关键索引缺失: "
                     f"{sorted(f'{table}.{index}' for table, index in missing_indexes)}。"
-                    "请先执行 'alembic upgrade head'。"
+                    "请先运行 'python -m Database.bootstrap'。"
                 )
                 logging.error(error_msg)
                 raise RuntimeError(error_msg)
@@ -436,7 +436,7 @@ def check_database_readiness():
         if e.errno == errorcode.ER_BAD_DB_ERROR:
             error_msg = (
                 f"数据库 '{settings.MYSQL_DATABASE}' 不存在。"
-                "请先运行 'python Database/database_init.py' 创建数据库。"
+                "请先运行 'python -m Database.bootstrap'。"
             )
             logging.error(error_msg)
             raise RuntimeError(error_msg) from e

--- a/docker-compose.replica.yml
+++ b/docker-compose.replica.yml
@@ -153,6 +153,8 @@ services:
         condition: service_healthy
       mysql-replica:
         condition: service_healthy
+      db-bootstrap:
+        condition: service_completed_successfully
     networks:
       - causalagent_replica_network
     restart: unless-stopped
@@ -215,19 +217,28 @@ services:
         condition: service_healthy
       mysql-replica:
         condition: service_healthy
-      checkpoint-setup:
+      db-bootstrap:
         condition: service_completed_successfully
     networks:
       - causalagent_replica_network
     restart: unless-stopped
 
-  checkpoint-setup:
+  db-bootstrap:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: causalagent_checkpoint_setup
-    command: python -m Database.checkpoint_setup
+    container_name: causalagent_db_bootstrap
+    command: python -m Database.bootstrap
     environment:
+      - MYSQL_HOST=mysql-primary
+      - MYSQL_WRITE_HOST=mysql-primary
+      - MYSQL_PORT=3306
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      - MYSQL_WRITE_USER=${MYSQL_WRITE_USER:-${MYSQL_USER}}
+      - MYSQL_WRITE_PASSWORD=${MYSQL_WRITE_PASSWORD:-${MYSQL_PASSWORD}}
+      - MYSQL_DATABASE=${MYSQL_DATABASE}
       - CHECKPOINT_POSTGRES_HOST=postgres-checkpoint
       - CHECKPOINT_POSTGRES_PORT=5432
       - CHECKPOINT_POSTGRES_DATABASE=${CHECKPOINT_POSTGRES_DATABASE:-causalagent_checkpoints}
@@ -239,6 +250,8 @@ services:
     volumes:
       - .:/app
     depends_on:
+      mysql-primary:
+        condition: service_healthy
       postgres-checkpoint:
         condition: service_healthy
     networks:
@@ -284,7 +297,7 @@ services:
         condition: service_healthy
       mysql-replica:
         condition: service_healthy
-      checkpoint-setup:
+      db-bootstrap:
         condition: service_completed_successfully
     networks:
       - causalagent_replica_network
@@ -345,6 +358,8 @@ services:
         condition: service_healthy
       mysql-replica:
         condition: service_healthy
+      db-bootstrap:
+        condition: service_completed_successfully
     networks:
       - causalagent_replica_network
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,6 +153,8 @@ services:
         condition: service_healthy
       mysql-replica:
         condition: service_healthy
+      db-bootstrap:
+        condition: service_completed_successfully
     networks:
       - causalagent_replica_network
     restart: unless-stopped
@@ -215,19 +217,28 @@ services:
         condition: service_healthy
       mysql-replica:
         condition: service_healthy
-      checkpoint-setup:
+      db-bootstrap:
         condition: service_completed_successfully
     networks:
       - causalagent_replica_network
     restart: unless-stopped
 
-  checkpoint-setup:
+  db-bootstrap:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: causalagent_checkpoint_setup
-    command: python -m Database.checkpoint_setup
+    container_name: causalagent_db_bootstrap
+    command: python -m Database.bootstrap
     environment:
+      - MYSQL_HOST=mysql-primary
+      - MYSQL_WRITE_HOST=mysql-primary
+      - MYSQL_PORT=3306
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      - MYSQL_WRITE_USER=${MYSQL_WRITE_USER:-${MYSQL_USER}}
+      - MYSQL_WRITE_PASSWORD=${MYSQL_WRITE_PASSWORD:-${MYSQL_PASSWORD}}
+      - MYSQL_DATABASE=${MYSQL_DATABASE}
       - CHECKPOINT_POSTGRES_HOST=postgres-checkpoint
       - CHECKPOINT_POSTGRES_PORT=5432
       - CHECKPOINT_POSTGRES_DATABASE=${CHECKPOINT_POSTGRES_DATABASE:-causalagent_checkpoints}
@@ -239,6 +250,8 @@ services:
     volumes:
       - .:/app
     depends_on:
+      mysql-primary:
+        condition: service_healthy
       postgres-checkpoint:
         condition: service_healthy
     networks:
@@ -284,7 +297,7 @@ services:
         condition: service_healthy
       mysql-replica:
         condition: service_healthy
-      checkpoint-setup:
+      db-bootstrap:
         condition: service_completed_successfully
     networks:
       - causalagent_replica_network
@@ -345,6 +358,8 @@ services:
         condition: service_healthy
       mysql-replica:
         condition: service_healthy
+      db-bootstrap:
+        condition: service_completed_successfully
     networks:
       - causalagent_replica_network
     restart: unless-stopped

--- a/tests/unit/database/test_bootstrap.py
+++ b/tests/unit/database/test_bootstrap.py
@@ -1,0 +1,69 @@
+"""统一数据库 bootstrap 编排测试。"""
+
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from Database import bootstrap
+
+
+class BootstrapTests(TestCase):
+    """验证 bootstrap 只负责编排既有数据库初始化职责。"""
+
+    def test_run_bootstrap_uses_mysql_then_alembic_then_postgres(self):
+        """统一入口必须按依赖顺序执行三个初始化阶段。"""
+        events: list[str] = []
+        mysql_bootstrap = MagicMock()
+        mysql_bootstrap.bootstrap.side_effect = lambda: events.append("mysql") or True
+
+        with (
+            patch(
+                "Database.bootstrap.create_mysql_bootstrap",
+                return_value=mysql_bootstrap,
+            ),
+            patch(
+                "Database.bootstrap.upgrade_mysql_schema",
+                side_effect=lambda project_root: events.append("alembic"),
+            ),
+            patch(
+                "Database.bootstrap.setup_postgres_checkpoint_schema",
+                side_effect=lambda: events.append("postgres"),
+            ),
+            patch("Database.bootstrap.LOGGER"),
+        ):
+            bootstrap.run_bootstrap(Path("C:/project"))
+
+        self.assertEqual(events, ["mysql", "alembic", "postgres"])
+
+    def test_run_bootstrap_stops_before_migration_when_mysql_is_unavailable(self):
+        """MySQL 连接检查失败时不能继续执行迁移或 PostgreSQL setup。"""
+        mysql_bootstrap = MagicMock()
+        mysql_bootstrap.bootstrap.return_value = False
+
+        with (
+            patch(
+                "Database.bootstrap.create_mysql_bootstrap",
+                return_value=mysql_bootstrap,
+            ),
+            patch("Database.bootstrap.upgrade_mysql_schema") as upgrade_mysql_schema,
+            patch(
+                "Database.bootstrap.setup_postgres_checkpoint_schema"
+            ) as setup_postgres_checkpoint_schema,
+            patch("Database.bootstrap.LOGGER"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "MySQL 数据库连接检查失败"):
+                bootstrap.run_bootstrap()
+
+        upgrade_mysql_schema.assert_not_called()
+        setup_postgres_checkpoint_schema.assert_not_called()
+
+    @patch("Database.bootstrap.command.upgrade")
+    def test_upgrade_mysql_schema_targets_head(self, upgrade):
+        """Alembic 编排必须使用仓库配置并升级到 head。"""
+        project_root = Path("C:/project")
+
+        bootstrap.upgrade_mysql_schema(project_root)
+
+        config, revision = upgrade.call_args.args
+        self.assertEqual(config.config_file_name, str(project_root / "alembic.ini"))
+        self.assertEqual(revision, "head")


### PR DESCRIPTION
- 新增 python -m Database.bootstrap，统一执行：MySQL 建库与连接检查
- Alembic migration
- LangGraph PostgreSQL checkpoint setup
- Compose 将 checkpoint-setup 改为一次性 db-bootstrap 服务。
- app、worker、monitor、checkpoint-cleanup 等待 bootstrap 成功后启动。
- 保留 python -m Database.checkpoint_setup 作为底层独立命令。
- 更新应用错误提示、README、AGENTS、管理员开发文档和开发日志。
- 新增 bootstrap 编排单测。