### PR TITLE
fix(job-lifecycle):保证任务终态提交与租约 fencing

### DIFF
--- a/README/开发日志.md
+++ b/README/开发日志.md
@@ -516,3 +516,7 @@
 - 【Quick 完整性状态标签】
   - Quick 完整性状态列改用 Element Plus 标签组件，healthy 显示绿色。
   - warning、error、danger 和 unknown 统一显示红色，保留后端返回的英文状态文字。
+- 【Job 终态与 worker 租约 BUG 修复】
+  - 成功终态将聊天保存、幂等标记、终态事件和 job=succeeded 收敛到同一个 MySQL 事务，提交前崩溃会整体回滚，重复终态调用不会重复保存聊天。
+  - worker 的事件、心跳、成功和失败更新统一校验 `job_id + worker_id + attempt_count`，旧 worker 失去租约后不能写事件、聊天或覆盖新 worker 结果。
+  - 领取任务时原子收敛心跳过期且已达到最大尝试次数的 running job，写入 error 事件、释放 `active_session_key` 并标记 failed。

--- a/app/agent/job_service.py
+++ b/app/agent/job_service.py
@@ -17,12 +17,14 @@ import mysql.connector
 from mysql.connector import errorcode
 
 from app.db import get_read_connection, get_read_connection_with_source, get_write_connection
+from app.chat.services import save_chat_for_job_in_transaction
 from config.settings import settings
 
 
 ACTIVE_STATUSES = ("queued", "running")
 TERMINAL_STATUSES = ("succeeded", "failed", "canceled")
 TERMINAL_EVENTS = {"final_result", "interrupt", "error"}
+MAX_ATTEMPTS_ERROR = "任务达到最大尝试次数，且最后一次 worker 心跳已过期"
 
 
 def _json_dumps(value: Any) -> str:
@@ -135,6 +137,53 @@ def create_job(user_id: int, session_id: str, message: str) -> tuple[dict[str, A
         conn.close()
 
 
+def _finalize_exhausted_job(cursor, stale_after: int) -> bool:
+    """锁定并失败一个已耗尽尝试次数且心跳过期的 job。"""
+    cursor.execute(
+        f"""
+        SELECT job_id
+        FROM analysis_jobs
+        WHERE status = 'running'
+          AND attempt_count >= max_attempts
+          AND (
+                heartbeat_at IS NULL
+                OR heartbeat_at < (UTC_TIMESTAMP(6) - INTERVAL {stale_after} SECOND)
+              )
+        ORDER BY heartbeat_at ASC, created_at ASC
+        LIMIT 1
+        FOR UPDATE SKIP LOCKED
+        """
+    )
+    job = cursor.fetchone()
+    if not job:
+        return False
+
+    cursor.execute(
+        """
+        UPDATE analysis_jobs
+        SET status = 'failed',
+            error_message = %s,
+            last_error = %s,
+            active_session_key = NULL,
+            heartbeat_at = UTC_TIMESTAMP(6),
+            finished_at = UTC_TIMESTAMP(6)
+        WHERE job_id = %s AND status = 'running'
+        """,
+        (MAX_ATTEMPTS_ERROR, MAX_ATTEMPTS_ERROR, job["job_id"]),
+    )
+    if cursor.rowcount != 1:
+        return False
+
+    cursor.execute(
+        """
+        INSERT INTO analysis_job_events (job_id, event_type, payload_json)
+        VALUES (%s, 'error', %s)
+        """,
+        (job["job_id"], _json_dumps({"type": "error", "message": MAX_ATTEMPTS_ERROR})),
+    )
+    return True
+
+
 def claim_next_job(worker_id: str, stale_after_seconds: int | None = None) -> dict[str, Any] | None:
     """
     领取一个可执行 job。
@@ -148,7 +197,7 @@ def claim_next_job(worker_id: str, stale_after_seconds: int | None = None) -> di
     try:
         cursor = conn.cursor(dictionary=True)
         conn.start_transaction()
-        ## 执行抢任务，并锁住
+        _finalize_exhausted_job(cursor, stale_after)
         cursor.execute(
             f"""
             SELECT *
@@ -157,7 +206,10 @@ def claim_next_job(worker_id: str, stale_after_seconds: int | None = None) -> di
                     status = 'queued'
                     OR (
                         status = 'running'
-                        AND heartbeat_at < (UTC_TIMESTAMP(6) - INTERVAL {stale_after} SECOND)
+                        AND (
+                            heartbeat_at IS NULL
+                            OR heartbeat_at < (UTC_TIMESTAMP(6) - INTERVAL {stale_after} SECOND)
+                        )
                     )
                   )
               AND attempt_count < max_attempts
@@ -201,35 +253,67 @@ def get_job_by_id(job_id: str) -> dict[str, Any] | None:
         return _row_to_job(cursor.fetchone())
 
 
-def update_heartbeat(job_id: str, worker_id: str) -> None:
-    """刷新 running job 的 worker 心跳，用于崩溃恢复判断。检测进程或者协是否正常"""
+def update_heartbeat(job_id: str, worker_id: str, attempt_count: int) -> bool:
+    """仅为持有指定 attempt 的 running job 刷新 worker 心跳。"""
     with get_write_connection() as conn:
         cursor = conn.cursor()
         cursor.execute(
             """
             UPDATE analysis_jobs
             SET heartbeat_at = UTC_TIMESTAMP(6)
-            WHERE job_id = %s AND worker_id = %s AND status = 'running'
+            WHERE job_id = %s
+              AND worker_id = %s
+              AND attempt_count = %s
+              AND status = 'running'
             """,
-            (job_id, worker_id),
+            (job_id, worker_id, attempt_count),
         )
         conn.commit()
+        return cursor.rowcount == 1
 
 
-def write_event(job_id: str, event_type: str, payload: dict[str, Any]) -> int:
-    """把 worker 产生的节点进度或终态事件写入事件表。"""
+def _lock_owned_running_job(cursor, job_id: str, worker_id: str, attempt_count: int) -> bool:
+    """锁定 job 行并确认它仍属于指定 worker attempt。"""
+    cursor.execute(
+        """
+        SELECT status, worker_id, attempt_count
+        FROM analysis_jobs
+        WHERE job_id = %s
+        FOR UPDATE
+        """,
+        (job_id,),
+    )
+    job = cursor.fetchone()
+    return bool(
+        job
+        and job["status"] == "running"
+        and job["worker_id"] == worker_id
+        and int(job["attempt_count"]) == int(attempt_count)
+    )
+
+
+def write_event(job_id: str, worker_id: str, attempt_count: int, event_type: str, payload: dict[str, Any]) -> int | None:
+    """仅为当前 worker attempt 写入一个事件，旧租约会被静默拒绝。"""
     with get_write_connection() as conn:
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            INSERT INTO analysis_job_events (job_id, event_type, payload_json)
-            VALUES (%s, %s, %s)
-            """,
-            (job_id, event_type, _json_dumps(payload)),
-        )
-        event_id = cursor.lastrowid
-        conn.commit()
-        return int(event_id)
+        try:
+            conn.start_transaction()
+            cursor = conn.cursor(dictionary=True)
+            if not _lock_owned_running_job(cursor, job_id, worker_id, attempt_count):
+                conn.rollback()
+                return None
+            cursor.execute(
+                """
+                INSERT INTO analysis_job_events (job_id, event_type, payload_json)
+                VALUES (%s, %s, %s)
+                """,
+                (job_id, event_type, _json_dumps(payload)),
+            )
+            event_id = cursor.lastrowid
+            conn.commit()
+            return int(event_id)
+        except Exception:
+            conn.rollback()
+            raise
 
 
 def read_events_after(job_id: str, after_id: int = 0, limit: int = 100) -> list[dict[str, Any]]:
@@ -252,8 +336,8 @@ def read_events_after(job_id: str, after_id: int = 0, limit: int = 100) -> list[
     return rows
 
 
-def complete_job(job_id: str, result: dict[str, Any] | None) -> None:
-    """把 job 标记为成功并保存最终结构化结果。"""
+def complete_job(job_id: str, worker_id: str, attempt_count: int, result: dict[str, Any] | None) -> bool:
+    """仅把当前 worker attempt 持有的 job 标记为成功。"""
     with get_write_connection() as conn:
         cursor = conn.cursor()
         cursor.execute(
@@ -265,48 +349,143 @@ def complete_job(job_id: str, result: dict[str, Any] | None) -> None:
                 heartbeat_at = UTC_TIMESTAMP(6),
                 finished_at = UTC_TIMESTAMP(6)
             WHERE job_id = %s
+              AND worker_id = %s
+              AND attempt_count = %s
+              AND status = 'running'
             """,
-            (_json_dumps(result or {}), job_id),
+            (_json_dumps(result or {}), job_id, worker_id, attempt_count),
         )
         conn.commit()
+        return cursor.rowcount == 1
 
 
-def fail_job(job_id: str, message: str, *, write_error_event: bool = True) -> None:
-    """把 job 标记为失败；必要时同时写入 error SSE 事件。"""
-    logging.error("analysis job %s failed: %s", job_id, message)
-    if write_error_event:
-        write_event(job_id, "error", {"type": "error", "message": message})
+def complete_job_with_chat(
+    job: dict[str, Any],
+    worker_id: str,
+    event_type: str,
+    payload: dict[str, Any],
+    chat_response: dict[str, Any],
+    result: dict[str, Any] | None,
+) -> bool:
+    """在一个事务内幂等保存聊天、写终态事件并完成当前 worker attempt。"""
+    job_id = job["job_id"]
+    attempt_count = int(job["attempt_count"])
     with get_write_connection() as conn:
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            UPDATE analysis_jobs
-            SET status = 'failed',
-                error_message = %s,
-                last_error = %s,
-                active_session_key = NULL,
-                heartbeat_at = UTC_TIMESTAMP(6),
-                finished_at = UTC_TIMESTAMP(6)
-            WHERE job_id = %s
-            """,
-            (message, message, job_id),
-        )
-        conn.commit()
+        try:
+            conn.start_transaction()
+            cursor = conn.cursor(dictionary=True)
+            if not _lock_owned_running_job(cursor, job_id, worker_id, attempt_count):
+                conn.rollback()
+                return False
+
+            save_chat_for_job_in_transaction(
+                cursor,
+                job_id,
+                job["user_id"],
+                job["session_id"],
+                job["message"],
+                chat_response,
+            )
+            cursor.execute(
+                """
+                INSERT INTO analysis_job_events (job_id, event_type, payload_json)
+                VALUES (%s, %s, %s)
+                """,
+                (job_id, event_type, _json_dumps(payload)),
+            )
+            cursor.execute(
+                """
+                UPDATE analysis_jobs
+                SET status = 'succeeded',
+                    result_json = %s,
+                    active_session_key = NULL,
+                    heartbeat_at = UTC_TIMESTAMP(6),
+                    finished_at = UTC_TIMESTAMP(6)
+                WHERE job_id = %s
+                  AND worker_id = %s
+                  AND attempt_count = %s
+                  AND status = 'running'
+                """,
+                (_json_dumps(result or {}), job_id, worker_id, attempt_count),
+            )
+            if cursor.rowcount != 1:
+                conn.rollback()
+                return False
+            conn.commit()
+            return True
+        except Exception:
+            conn.rollback()
+            raise
 
 
-def mark_chat_saved(job_id: str) -> bool:
-    """幂等标记聊天历史已保存；返回本次调用是否真正写入标记。"""
+def fail_job(
+    job_id: str,
+    worker_id: str,
+    attempt_count: int,
+    message: str,
+    *,
+    write_error_event: bool = True,
+) -> bool:
+    """仅把当前 worker attempt 持有的 job 标记为失败并可写入 error 事件。"""
+    logging.error("analysis job %s failed: %s", job_id, message)
+    with get_write_connection() as conn:
+        try:
+            conn.start_transaction()
+            cursor = conn.cursor(dictionary=True)
+            if not _lock_owned_running_job(cursor, job_id, worker_id, attempt_count):
+                conn.rollback()
+                return False
+            if write_error_event:
+                cursor.execute(
+                    """
+                    INSERT INTO analysis_job_events (job_id, event_type, payload_json)
+                    VALUES (%s, 'error', %s)
+                    """,
+                    (job_id, _json_dumps({"type": "error", "message": message})),
+                )
+            cursor.execute(
+                """
+                UPDATE analysis_jobs
+                SET status = 'failed',
+                    error_message = %s,
+                    last_error = %s,
+                    active_session_key = NULL,
+                    heartbeat_at = UTC_TIMESTAMP(6),
+                    finished_at = UTC_TIMESTAMP(6)
+                WHERE job_id = %s
+                  AND worker_id = %s
+                  AND attempt_count = %s
+                  AND status = 'running'
+                """,
+                (message, message, job_id, worker_id, attempt_count),
+            )
+            if cursor.rowcount != 1:
+                conn.rollback()
+                return False
+            conn.commit()
+            return True
+        except Exception:
+            conn.rollback()
+            raise
+
+
+def mark_chat_saved(job_id: str, worker_id: str, attempt_count: int) -> bool:
+    """仅为当前 worker attempt 幂等标记聊天历史已保存。"""
     with get_write_connection() as conn:
         cursor = conn.cursor()
         cursor.execute(
             """
             UPDATE analysis_jobs
             SET chat_saved_at = UTC_TIMESTAMP(6)
-            WHERE job_id = %s AND chat_saved_at IS NULL
+            WHERE job_id = %s
+              AND worker_id = %s
+              AND attempt_count = %s
+              AND status = 'running'
+              AND chat_saved_at IS NULL
             """,
-            (job_id,),
+            (job_id, worker_id, attempt_count),
         )
-        changed = cursor.rowcount > 0
+        changed = cursor.rowcount == 1
         conn.commit()
         return changed
 

--- a/app/agent/worker.py
+++ b/app/agent/worker.py
@@ -23,7 +23,6 @@ from Agent.causal_agent.postgres_checkpointer import (
 )
 from app.agent import core as agent_core
 from app.agent import job_service
-from app.chat.services import save_chat
 from app.db import check_database_readiness
 from config.settings import settings
 
@@ -35,19 +34,33 @@ def _parse_sse_payload(event_data: str) -> dict[str, Any]:
     return json.loads(event_data[6:].strip())
 
 
-async def _heartbeat_until_stopped(job_id: str, worker_id: str, stop: asyncio.Event) -> None:
+async def _heartbeat_until_stopped(
+    job_id: str,
+    worker_id: str,
+    attempt_count: int,
+    stop: asyncio.Event,
+) -> None:
     """在 job 执行期间定期刷新 heartbeat_at，直到 stop 被设置。"""
     # 持续检查stop是否为true
     while not stop.is_set():
         await asyncio.sleep(settings.JOB_HEARTBEAT_INTERVAL_SECONDS)
         if stop.is_set():
             break
-        await asyncio.to_thread(job_service.update_heartbeat, job_id, worker_id)
+        await asyncio.to_thread(
+            job_service.update_heartbeat,
+            job_id,
+            worker_id,
+            attempt_count,
+        )
         logging.info("[worker] heartbeat job=%s worker=%s", job_id, worker_id)
 
 
-async def _save_chat_for_terminal_event(job: dict[str, Any], payload: dict[str, Any]) -> None:
-    """在 final_result 或 interrupt 后保存聊天历史，并写入幂等标记。"""
+async def _complete_terminal_event(
+    job: dict[str, Any],
+    worker_id: str,
+    payload: dict[str, Any],
+) -> bool:
+    """在一个事务内完成终态事件、聊天保存和 job 成功更新。"""
     event_type = payload.get("type")
     if event_type == "final_result":
         response_data = payload.get("data", {})
@@ -57,18 +70,18 @@ async def _save_chat_for_terminal_event(job: dict[str, Any], payload: dict[str, 
             "summary": payload.get("message", ""),
         }
     else:
-        return
+        return False
 
-    saved = await asyncio.to_thread(
-        save_chat,
-        job["user_id"],
-        job["session_id"],
-        job["message"],
+    result = payload.get("data") if event_type == "final_result" else payload
+    return await asyncio.to_thread(
+        job_service.complete_job_with_chat,
+        job,
+        worker_id,
+        event_type,
+        payload,
         response_data,
+        result,
     )
-    if not saved:
-        raise RuntimeError("聊天历史保存失败")
-    await asyncio.to_thread(job_service.mark_chat_saved, job["job_id"])
 
 
 async def _run_job(job: dict[str, Any], graph, worker_id: str) -> None:
@@ -76,7 +89,9 @@ async def _run_job(job: dict[str, Any], graph, worker_id: str) -> None:
     job_id = job["job_id"]
     stop_heartbeat = asyncio.Event()
     # 心跳检测协程是否正常进行
-    heartbeat_task = asyncio.create_task(_heartbeat_until_stopped(job_id, worker_id, stop_heartbeat))
+    heartbeat_task = asyncio.create_task(
+        _heartbeat_until_stopped(job_id, worker_id, int(job["attempt_count"]), stop_heartbeat)
+    )
     # 标记是否该job是否结束
     terminal_seen = False
     final_result = None
@@ -94,29 +109,47 @@ async def _run_job(job: dict[str, Any], graph, worker_id: str) -> None:
         ):
             payload = _parse_sse_payload(event_data)
             event_type = payload.get("type", "message")
-            # 将获取到的值落库
-            await asyncio.to_thread(job_service.write_event, job_id, event_type, payload)
 
             if event_type in {"final_result", "interrupt"}:
-                await _save_chat_for_terminal_event(job, payload)
-                final_result = payload.get("data") if event_type == "final_result" else payload
-                await asyncio.to_thread(job_service.complete_job, job_id, final_result)
+                await _complete_terminal_event(job, worker_id, payload)
                 terminal_seen = True
             elif event_type == "error":
                 await asyncio.to_thread(
                     job_service.fail_job,
                     job_id,
+                    worker_id,
+                    int(job["attempt_count"]),
                     payload.get("message", "任务执行失败"),
-                    write_error_event=False,
                 )
                 terminal_seen = True
+            else:
+                await asyncio.to_thread(
+                    job_service.write_event,
+                    job_id,
+                    worker_id,
+                    int(job["attempt_count"]),
+                    event_type,
+                    payload,
+                )
 
         if not terminal_seen:
-            await asyncio.to_thread(job_service.complete_job, job_id, final_result or {})
+            await asyncio.to_thread(
+                job_service.complete_job,
+                job_id,
+                worker_id,
+                int(job["attempt_count"]),
+                final_result or {},
+            )
         logging.info("[worker] finish job=%s worker=%s", job_id, worker_id)
     except Exception as exc:
         logging.error("[worker] job failed job=%s worker=%s error=%s", job_id, worker_id, exc, exc_info=True)
-        await asyncio.to_thread(job_service.fail_job, job_id, str(exc))
+        await asyncio.to_thread(
+            job_service.fail_job,
+            job_id,
+            worker_id,
+            int(job["attempt_count"]),
+            str(exc),
+        )
     ## 如果结束，停止心跳
     finally:
         stop_heartbeat.set()

--- a/app/chat/services.py
+++ b/app/chat/services.py
@@ -51,83 +51,124 @@ class SessionNotFoundError(ValueError):
     """表示写入请求引用了不存在或不属于当前用户的会话。"""
 
 
+def _save_chat_rows(cursor, user_id, session_id, user_msg, ai_response, timestamp_dt):
+    """使用已有事务游标写入聊天消息、附件和会话元数据，不提交事务。"""
+    cursor.execute(
+        "SELECT message_count, title FROM sessions WHERE id = %s AND user_id = %s FOR UPDATE",
+        (session_id, user_id),
+    )
+    session_data = cursor.fetchone()
+
+    if not session_data:
+        raise SessionNotFoundError("会话不存在或无权访问")
+
+    is_first_message = session_data["message_count"] == 0
+    cursor.execute(
+        """
+        INSERT INTO chat_messages (session_id, user_id, message_type, content, created_at)
+        VALUES (%s, %s, 'user', %s, %s)
+        """,
+        (session_id, user_id, user_msg, timestamp_dt),
+    )
+
+    ai_content, attachment_to_save = prepare_ai_response_for_storage(ai_response)
+    has_attachment = len(attachment_to_save) > 0
+    cursor.execute(
+        """
+        INSERT INTO chat_messages (session_id, user_id, message_type, content, has_attachment, created_at)
+        VALUES (%s, %s, 'ai', %s, %s, %s)
+        """,
+        (session_id, user_id, ai_content, has_attachment, timestamp_dt),
+    )
+    ai_message_id = cursor.lastrowid
+
+    if has_attachment and attachment_to_save:
+        for attachment in attachment_to_save:
+            logging.info(
+                "准备保存附件: type=%s, content_size=%s 字节",
+                attachment["type"],
+                len(attachment["content"]),
+            )
+            cursor.execute(
+                """
+                INSERT INTO chat_attachments (message_id, attachment_type, content, created_at)
+                VALUES (%s, %s, %s, %s)
+                """,
+                (ai_message_id, attachment["type"], attachment["content"], timestamp_dt),
+            )
+
+    if is_first_message:
+        new_title = build_session_title(user_msg)
+        cursor.execute(
+            """
+            UPDATE sessions
+            SET title = %s, last_activity_at = %s, message_count = message_count + 2
+            WHERE id = %s AND user_id = %s
+            """,
+            (new_title, timestamp_dt, session_id, user_id),
+        )
+    else:
+        cursor.execute(
+            """
+            UPDATE sessions
+            SET last_activity_at = %s, message_count = message_count + 2
+            WHERE id = %s AND user_id = %s
+            """,
+            (timestamp_dt, session_id, user_id),
+        )
+
+
+def save_chat_for_job_in_transaction(
+    cursor,
+    job_id,
+    user_id,
+    session_id,
+    user_msg,
+    ai_response,
+) -> bool:
+    """在 worker 的终态事务中幂等保存聊天，不提交调用方事务。"""
+    cursor.execute(
+        """
+        SELECT chat_saved_at
+        FROM analysis_jobs
+        WHERE job_id = %s AND user_id = %s
+        FOR UPDATE
+        """,
+        (job_id, user_id),
+    )
+    job_data = cursor.fetchone()
+    if not job_data:
+        raise ValueError("任务不存在或不属于当前用户")
+    if job_data["chat_saved_at"] is not None:
+        return False
+
+    cursor.execute(
+        """
+        UPDATE analysis_jobs
+        SET chat_saved_at = UTC_TIMESTAMP(6)
+        WHERE job_id = %s AND user_id = %s AND chat_saved_at IS NULL
+        """,
+        (job_id, user_id),
+    )
+    if cursor.rowcount != 1:
+        return False
+
+    _save_chat_rows(cursor, user_id, session_id, user_msg, ai_response, datetime.now())
+    return True
+
+
 def save_chat(user_id, session_id, user_msg, ai_response):
-    """
-    将用户和 AI 的交互保存到数据库中。
-    - 只接受已由 new_chat 创建且仍归属于当前用户的 session
-    - 在 chat_messages 中为用户和AI分别创建记录。
-    - 如果AI响应包含附件，则在 chat_attachments 中创建记录。
-    - 更新 sessions 表的元数据。
-    """
+    """独立事务保存用户和 AI 的聊天消息、附件及会话元数据。"""
     timestamp_dt = datetime.now()
 
     try:
         with get_write_connection() as conn:
             cursor = conn.cursor(dictionary=True)
-
-            cursor.execute(
-                "SELECT message_count, title FROM sessions WHERE id = %s AND user_id = %s FOR UPDATE",
-                (session_id, user_id),
-            )
-            session_data = cursor.fetchone()
-            
-            if not session_data:
+            try:
+                _save_chat_rows(cursor, user_id, session_id, user_msg, ai_response, timestamp_dt)
+            except SessionNotFoundError:
                 conn.rollback()
-                raise SessionNotFoundError("会话不存在或无权访问")
-
-            is_first_message = session_data['message_count'] == 0
-            
-            # 保存用户消息
-            sql_user = """
-                INSERT INTO chat_messages (session_id, user_id, message_type, content, created_at)
-                VALUES (%s, %s, 'user', %s, %s)
-            """
-            cursor.execute(sql_user, (session_id, user_id, user_msg, timestamp_dt))
-            
-            # 保存AI消息
-            ai_content, attachment_to_save = prepare_ai_response_for_storage(ai_response)
-            
-            # 处理数据库保存格式
-            sql_ai = """
-                INSERT INTO chat_messages (session_id, user_id, message_type, content, has_attachment, created_at)
-                VALUES (%s, %s, 'ai', %s, %s, %s)
-            """
-            has_attachment = len(attachment_to_save) > 0
-            cursor.execute(sql_ai, (session_id, user_id, ai_content, has_attachment, timestamp_dt))
-            ai_message_id = cursor.lastrowid # 获取AI消息的ID，用于关联附件
-
-            # 3. 如果有附件，保存到 chat_attachments
-            if has_attachment and attachment_to_save:
-                for attachment in attachment_to_save:
-                    sql_attachment = """
-                    INSERT INTO chat_attachments (message_id, attachment_type, content, created_at)
-                    VALUES (%s, %s, %s, %s)
-                    """
-                    logging.info(f"准备保存附件: type={attachment['type']}, content_size={len(attachment['content'])} 字节")
-                    cursor.execute(sql_attachment,
-                    (ai_message_id, attachment['type'], attachment['content'], timestamp_dt))
-                    logging.info(f"成功保存附件: {attachment['type']}")
-            
-
-            # 根据是否为第一条消息，决定是否更新标题
-            if is_first_message:
-                #  更新会话，包括新标题（或确认创建时的标题）
-                new_title = build_session_title(user_msg)
-                sql_update_session = """
-                    UPDATE sessions 
-                    SET title = %s, last_activity_at = %s, message_count = message_count + 2
-                    WHERE id = %s AND user_id = %s
-                """
-                cursor.execute(sql_update_session, (new_title, timestamp_dt, session_id, user_id))
-            else:
-                #  只更新活动时间和消息数
-                sql_update_session = """
-                    UPDATE sessions 
-                    SET last_activity_at = %s, message_count = message_count + 2
-                    WHERE id = %s AND user_id = %s
-                """
-                cursor.execute(sql_update_session, (timestamp_dt, session_id, user_id))
-            
+                raise
             conn.commit()
             return True
     except SessionNotFoundError:

--- a/tests/unit/agent/test_job_lifecycle.py
+++ b/tests/unit/agent/test_job_lifecycle.py
@@ -1,0 +1,232 @@
+import os
+import unittest
+from unittest.mock import patch
+
+
+TEST_ENV = {
+    "SECRET_KEY": "test-secret",
+    "API_KEY": "test-api-key",
+    "BASE_URL": "https://example.test",
+    "MODEL": "test-model",
+    "MYSQL_HOST": "test-mysql",
+    "MYSQL_USER": "test-user",
+    "MYSQL_PASSWORD": "test-password",
+    "MYSQL_DATABASE": "test-database",
+}
+for key, value in TEST_ENV.items():
+    os.environ.setdefault(key, value)
+
+from app.agent.job_service import (  # noqa: E402
+    MAX_ATTEMPTS_ERROR,
+    claim_next_job,
+    complete_job,
+    complete_job_with_chat,
+    fail_job,
+    write_event,
+)
+
+
+class FakeCursor:
+    """记录 SQL，并按顺序返回预设的锁定查询结果。"""
+
+    def __init__(self, fetch_results=None, rowcount=1):
+        self.fetch_results = list(fetch_results or [])
+        self.rowcount = rowcount
+        self.lastrowid = 17
+        self.statements = []
+
+    def execute(self, sql, params=None):
+        self.statements.append((" ".join(sql.split()), params))
+
+    def fetchone(self):
+        return self.fetch_results.pop(0) if self.fetch_results else None
+
+
+class FakeConnection:
+    """模拟 worker 事务连接，并记录提交与回滚次数。"""
+
+    def __init__(self, fetch_results=None, rowcount=1, fail_commit=False):
+        self.fake_cursor = FakeCursor(fetch_results, rowcount=rowcount)
+        self.started_transactions = 0
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.fail_commit = fail_commit
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def cursor(self, **kwargs):
+        return self.fake_cursor
+
+    def start_transaction(self):
+        self.started_transactions += 1
+
+    def commit(self):
+        self.commits += 1
+        if self.fail_commit:
+            raise RuntimeError("commit failed")
+
+    def rollback(self):
+        self.rollbacks += 1
+
+    def close(self):
+        self.closed = True
+
+
+def build_job(attempt_count=2):
+    """构造一个由指定 attempt 持有的最小 job。"""
+    return {
+        "job_id": "job-1",
+        "user_id": 7,
+        "session_id": "session-1",
+        "message": "hello",
+        "attempt_count": attempt_count,
+    }
+
+
+class JobLifecycleTests(unittest.TestCase):
+    """验证 job 终态事务、租约 fencing 和重试耗尽收敛。"""
+
+    def test_terminal_success_commits_chat_event_and_job_together(self):
+        """成功终态必须先设置幂等标记，再在一次事务中写完所有数据。"""
+        connection = FakeConnection(
+            fetch_results=[
+                {"status": "running", "worker_id": "worker-a", "attempt_count": 2},
+                {"chat_saved_at": None},
+                {"message_count": 0, "title": "新对话"},
+            ]
+        )
+
+        with patch("app.agent.job_service.get_write_connection", return_value=connection):
+            saved = complete_job_with_chat(
+                build_job(),
+                "worker-a",
+                "final_result",
+                {"type": "final_result", "data": {"summary": "done"}},
+                {"type": "text", "summary": "done"},
+                {"summary": "done"},
+            )
+
+        self.assertTrue(saved)
+        self.assertEqual(connection.started_transactions, 1)
+        self.assertEqual(connection.commits, 1)
+        self.assertEqual(connection.rollbacks, 0)
+        sql = [statement for statement, _params in connection.fake_cursor.statements]
+        marker_index = next(i for i, statement in enumerate(sql) if "SET chat_saved_at" in statement)
+        chat_insert_index = next(i for i, statement in enumerate(sql) if "INSERT INTO chat_messages" in statement)
+        event_index = next(i for i, statement in enumerate(sql) if "INSERT INTO analysis_job_events" in statement)
+        status_index = next(i for i, statement in enumerate(sql) if "SET status = 'succeeded'" in statement)
+        self.assertLess(marker_index, chat_insert_index)
+        self.assertLess(event_index, status_index)
+
+    def test_terminal_commit_error_rolls_back_all_changes(self):
+        """终态提交失败时必须回滚聊天、事件和 job 更新。"""
+        connection = FakeConnection(
+            fetch_results=[
+                {"status": "running", "worker_id": "worker-a", "attempt_count": 2},
+                {"chat_saved_at": None},
+                {"message_count": 1, "title": "existing"},
+            ],
+            fail_commit=True,
+        )
+
+        with patch("app.agent.job_service.get_write_connection", return_value=connection):
+            with self.assertRaisesRegex(RuntimeError, "commit failed"):
+                complete_job_with_chat(
+                    build_job(),
+                    "worker-a",
+                    "final_result",
+                    {"type": "final_result", "data": {"summary": "done"}},
+                    {"type": "text", "summary": "done"},
+                    {"summary": "done"},
+                )
+
+        self.assertEqual(connection.commits, 1)
+        self.assertEqual(connection.rollbacks, 1)
+
+    def test_existing_chat_marker_skips_duplicate_chat_rows(self):
+        """重试看到已提交的聊天标记时不得再次插入消息。"""
+        connection = FakeConnection(
+            fetch_results=[
+                {"status": "running", "worker_id": "worker-a", "attempt_count": 2},
+                {"chat_saved_at": "2026-08-04 12:00:00"},
+            ]
+        )
+
+        with patch("app.agent.job_service.get_write_connection", return_value=connection):
+            saved = complete_job_with_chat(
+                build_job(),
+                "worker-a",
+                "final_result",
+                {"type": "final_result", "data": {"summary": "done"}},
+                {"type": "text", "summary": "done"},
+                {"summary": "done"},
+            )
+
+        self.assertTrue(saved)
+        self.assertEqual(connection.commits, 1)
+        self.assertFalse(any("INSERT INTO chat_messages" in sql for sql, _ in connection.fake_cursor.statements))
+
+    def test_stale_worker_cannot_write_event_or_fail_new_attempt(self):
+        """旧 worker 的事件和失败更新都必须被当前租约检查拒绝。"""
+        event_connection = FakeConnection(
+            fetch_results=[{"status": "running", "worker_id": "worker-new", "attempt_count": 3}]
+        )
+        with patch("app.agent.job_service.get_write_connection", return_value=event_connection):
+            event_id = write_event("job-1", "worker-old", 2, "progress", {"value": 1})
+
+        self.assertIsNone(event_id)
+        self.assertEqual(event_connection.commits, 0)
+        self.assertEqual(event_connection.rollbacks, 1)
+        self.assertFalse(any("INSERT INTO analysis_job_events" in sql for sql, _ in event_connection.fake_cursor.statements))
+
+        fail_connection = FakeConnection(
+            fetch_results=[{"status": "running", "worker_id": "worker-new", "attempt_count": 3}]
+        )
+        with patch("app.agent.job_service.get_write_connection", return_value=fail_connection):
+            failed = fail_job("job-1", "worker-old", 2, "old failure")
+
+        self.assertFalse(failed)
+        self.assertEqual(fail_connection.commits, 0)
+        self.assertEqual(fail_connection.rollbacks, 1)
+        self.assertFalse(any("SET status = 'failed'" in sql for sql, _ in fail_connection.fake_cursor.statements))
+
+    def test_complete_job_sql_requires_worker_and_attempt(self):
+        """非聊天成功更新也必须在 SQL 层带上 worker 和 attempt fencing。"""
+        connection = FakeConnection(rowcount=0)
+        with patch("app.agent.job_service.get_write_connection", return_value=connection):
+            completed = complete_job("job-1", "worker-old", 2, {"summary": "done"})
+
+        self.assertFalse(completed)
+        sql, params = connection.fake_cursor.statements[0]
+        self.assertIn("worker_id = %s", sql)
+        self.assertIn("attempt_count = %s", sql)
+        self.assertEqual(params[-2:], ("worker-old", 2))
+
+    def test_claim_final_exhausted_job_as_failed_and_releases_session(self):
+        """领取时应收敛过期且耗尽尝试次数的 running job，避免永久占用会话。"""
+        connection = FakeConnection(
+            fetch_results=[{"job_id": "job-max"}, None]
+        )
+
+        with patch("app.agent.job_service.get_write_connection", return_value=connection):
+            claimed = claim_next_job("worker-a", stale_after_seconds=120)
+
+        self.assertIsNone(claimed)
+        self.assertEqual(connection.started_transactions, 1)
+        self.assertEqual(connection.commits, 1)
+        sql = [statement for statement, _params in connection.fake_cursor.statements]
+        self.assertTrue(any("SET status = 'failed'" in statement for statement in sql))
+        self.assertTrue(any("active_session_key = NULL" in statement for statement in sql))
+        event_statement = next(statement for statement in sql if "INSERT INTO analysis_job_events" in statement)
+        self.assertIn("VALUES (%s, 'error', %s)", event_statement)
+        update_params = next(params for statement, params in connection.fake_cursor.statements if "SET status = 'failed'" in statement)
+        self.assertEqual(update_params[:2], (MAX_ATTEMPTS_ERROR, MAX_ATTEMPTS_ERROR))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- 终态聊天、chat_saved_at、终态事件和 job=succeeded 合并为单事务提交。
- 所有 worker 写操作校验 job_id + worker_id + attempt_count，旧 worker 无法覆盖新任务。
- chat_saved_at 改为保存前幂等闸门，避免重试重复聊天。
- 最大尝试次数且心跳过期的任务会原子标记为 failed，并释放 active_session_key。
- 新增 9 项生命周期测试。